### PR TITLE
Database Property Not Set in MongoDBStorage

### DIFF
--- a/Orleans.Providers.MongoDB/StorageProviders/MongoDBStorageProvider.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoDBStorageProvider.cs
@@ -49,6 +49,10 @@
             {
                 this.Database = MongoUrl.Create(this.ConnectionString).DatabaseName;
             }
+            else
+            {
+                this.Database = config.Properties["Database"];
+            }
 
             if (string.IsNullOrWhiteSpace(this.ConnectionString)) throw new ArgumentException("ConnectionString property not set");
             if (string.IsNullOrWhiteSpace(this.Database)) throw new ArgumentException("Database property not set");

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoDBStorageProvider.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoDBStorageProvider.cs
@@ -45,7 +45,7 @@
             this.Name = name;
             this.ConnectionString = config.Properties["ConnectionString"];
 
-            if (string.IsNullOrEmpty(config.Properties["Database"]))
+            if (!config.Properties.ContainsKey("Database") || string.IsNullOrEmpty(config.Properties["Database"]))
             {
                 this.Database = MongoUrl.Create(this.ConnectionString).DatabaseName;
             }


### PR DESCRIPTION
When the database name is provided embedded within the connection string (e.g. ConnectionString="...myserver:1111/databaseName"), the MongoDBStorage fails to initialize because it checks for the database parameter in the config dictionary which may not have the key "Database". Additionally if the database name is provided as an independent parameter (e.g. Database="databaseName") then the MongoDBStorage.database property is never set and it fails to initialize as well.

It seemed like a minor oversight from repurposing the original sample provider from dotnet/orleans, so I fixed it such that the property gets set in both conditions as expected.