### PR TITLE
Fix Database name in MongoReminderTable

### DIFF
--- a/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
+++ b/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
@@ -32,7 +32,7 @@ namespace Orleans.Providers.MongoDB.Reminders
                 connectionString = config.DataConnectionString;
 
             repository = new MongoReminderTableRepository(connectionString,
-                MongoUrl.Create(config.DataConnectionString).DatabaseName, grainReferenceConverter);
+                MongoUrl.Create(connectionString).DatabaseName, grainReferenceConverter);
             await repository.InitTables();
         }
 


### PR DESCRIPTION
MongoReminderTable used the wrong ConnectionString to determine the database name