### PR TITLE
V2 Storage Provider

### DIFF
--- a/Orleans.Providers.MongoDB/MongoDBConfigurationExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBConfigurationExtensions.cs
@@ -9,6 +9,7 @@ using Orleans.Providers.MongoDB.Membership;
 using Orleans.Providers.MongoDB.Reminders;
 using Orleans.Providers.MongoDB.Statistics;
 using Orleans.Providers.MongoDB.StorageProviders;
+using Orleans.Providers.MongoDB.StorageProviders.V2;
 using Orleans.Runtime.Configuration;
 
 // ReSharper disable AccessToStaticMemberViaDerivedType
@@ -264,15 +265,67 @@ namespace Orleans
         /// </summary>
         /// <param name="config">The cluster configuration object to add provider to.</param>
         /// <param name="providerName">The provider name.</param>
+        /// <param name="configurator">The configurator.</param>
+        public static void AddMongoDBStorageProviderV2(this ClusterConfiguration config, string providerName,
+            Action<MongoDBStorageOptions> configurator = null)
+        {
+            var options = new MongoDBStorageOptions();
+
+            configurator?.Invoke(options);
+
+            options.EnrichAndValidate(config.Globals, false);
+
+            AddMongoDBStorageProviderV2<MongoStorageProviderV2>(config, providerName, options);
+        }
+
+        /// <summary>
+        /// Adds a storage provider of type <see cref="MongoStorageProvider"/>.
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
         /// <param name="configuration">The configuration.</param>
-        public static void AddMongoDBStorageProvider<T>(this ClusterConfiguration config, string providerName,
-            IConfiguration configuration) where T : MongoStorageProvider
+        public static void AddMongoDBStorageProviderV2(this ClusterConfiguration config, string providerName,
+            IConfiguration configuration)
         {
             var options = configuration.Get<MongoDBStorageOptions>();
 
             options.EnrichAndValidate(config.Globals, false);
 
-            AddMongoDBStorageProvider<T>(config, providerName, options);
+            AddMongoDBStorageProviderV2<MongoStorageProviderV2>(config, providerName, options);
+        }
+
+        /// <summary>
+        /// Adds a storage provider of type <see cref="MongoStorageProvider"/>.
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        /// <param name="configurator">The configurator.</param>
+        public static void AddMongoDBStorageProviderV2<T>(this ClusterConfiguration config, string providerName,
+            Action<MongoDBStorageOptions> configurator = null) where T : MongoStorageProviderV2
+        {
+            var options = new MongoDBStorageOptions();
+
+            configurator?.Invoke(options);
+
+            options.EnrichAndValidate(config.Globals, false);
+
+            AddMongoDBStorageProviderV2<T>(config, providerName, options);
+        }
+
+        /// <summary>
+        /// Adds a storage provider of type <see cref="MongoStorageProvider"/>.
+        /// </summary>
+        /// <param name="config">The cluster configuration object to add provider to.</param>
+        /// <param name="providerName">The provider name.</param>
+        /// <param name="configuration">The configuration.</param>
+        public static void AddMongoDBStorageProviderV2<T>(this ClusterConfiguration config, string providerName,
+            IConfiguration configuration) where T : MongoStorageProviderV2
+        {
+            var options = configuration.Get<MongoDBStorageOptions>();
+
+            options.EnrichAndValidate(config.Globals, false);
+
+            AddMongoDBStorageProviderV2<T>(config, providerName, options);
         }
 
         /// <summary>
@@ -351,6 +404,18 @@ namespace Orleans
                 { MongoStorageProvider.CollectionPrefixProperty, options.CollectionPrefix },
                 { MongoStorageProvider.DatabaseNameProperty, options.DatabaseName },
                 { MongoStorageProvider.UseJsonFormatProperty, options.UseJsonFormat.ToString() }
+            };
+
+            config.Globals.RegisterStorageProvider<T>(providerName, properties);
+        }
+
+        private static void AddMongoDBStorageProviderV2<T>(ClusterConfiguration config, string providerName, MongoDBStorageOptions options) where T : MongoStorageProviderV2
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { MongoStorageProviderV2.ConnectionStringProperty, options.ConnectionString },
+                { MongoStorageProviderV2.CollectionPrefixProperty, options.CollectionPrefix },
+                { MongoStorageProviderV2.DatabaseNameProperty, options.DatabaseName }
             };
 
             config.Globals.RegisterStorageProvider<T>(providerName, properties);

--- a/Orleans.Providers.MongoDB/StorageProviders/FileStorageProvider.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/FileStorageProvider.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Orleans.Providers.MongoDB.StorageProviders
 {
     public class FileStorageProvider : BaseJSONStorageProvider
     {
+        public FileStorageProvider(ILogger<BaseJSONStorageProvider> logger) 
+            : base(logger)
+        {
+        }
+
         public override Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
         {
             var rootDirectory = config.Properties["RootDirectory"];

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoStorageProvider.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoStorageProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 
 namespace Orleans.Providers.MongoDB.StorageProviders
@@ -10,6 +11,11 @@ namespace Orleans.Providers.MongoDB.StorageProviders
         public const string DatabaseNameProperty = "DatabaseProperty";
 
         private string prefix;
+
+        public MongoStorageProvider(ILogger<BaseJSONStorageProvider> logger)
+            : base(logger)
+        {
+        }
 
         public override Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
         {

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonHelper.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonHelper.cs
@@ -1,0 +1,31 @@
+﻿
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public static class BsonHelper
+    {
+        public static string UnescapeBson(this string value)
+        {
+            return ReplaceFirstCharacter(value, '§', '$');
+        }
+
+        public static string EscapeJson(this string value)
+        {
+            return ReplaceFirstCharacter(value, '$', '§');
+        }
+
+        private static string ReplaceFirstCharacter(string value, char toReplace, char replacement)
+        {
+            if (value.Length == 0 || value[0] != toReplace)
+            {
+                return value;
+            }
+
+            if (value.Length == 1)
+            {
+                return toReplace.ToString();
+            }
+
+            return replacement + value.Substring(1);
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonAttribute.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class BsonJsonAttribute : Attribute
+    {
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonConvention.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonConvention.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using Newtonsoft.Json;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public static class BsonJsonConvention
+    {
+        public static void Register(JsonSerializer serializer)
+        {
+            var pack = new ConventionPack();
+
+            pack.AddMemberMapConvention("JsonBson", memberMap =>
+            {
+                var attributes = memberMap.MemberInfo.GetCustomAttributes();
+
+                if (attributes.OfType<BsonJsonAttribute>().Any())
+                {
+                    var bsonSerializerType = typeof(BsonJsonSerializer<>).MakeGenericType(memberMap.MemberType);
+                    var bsonSerializer = Activator.CreateInstance(bsonSerializerType, serializer);
+
+                    memberMap.SetSerializer((IBsonSerializer)bsonSerializer);
+                }
+            });
+
+            ConventionRegistry.Register("json", pack, t => true);
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonConverter.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using MongoDB.Bson;
+using Newtonsoft.Json.Linq;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public static class BsonJsonConverter
+    {
+        public static BsonDocument ToBson(this JObject source)
+        {
+            var result = new BsonDocument();
+
+            foreach (var property in source)
+            {
+                result.Add(property.Key.EscapeJson(), property.Value.ToBson());
+            }
+
+            return result;
+        }
+
+        public static JObject ToJson(this BsonDocument source)
+        {
+            var result = new JObject();
+
+            foreach (var property in source)
+            {
+                result.Add(property.Name.UnescapeBson(), property.Value.ToJson());
+            }
+
+            return result;
+        }
+
+        public static BsonArray ToBson(this JArray source)
+        {
+            var result = new BsonArray();
+
+            foreach (var item in source)
+            {
+                result.Add(item.ToBson());
+            }
+
+            return result;
+        }
+
+        public static JArray ToJson(this BsonArray source)
+        {
+            var result = new JArray();
+
+            foreach (var item in source)
+            {
+                result.Add(item.ToJson());
+            }
+
+            return result;
+        }
+
+        public static BsonValue ToBson(this JToken source)
+        {
+            switch (source.Type)
+            {
+                case JTokenType.Object:
+                    return ((JObject)source).ToBson();
+                case JTokenType.Array:
+                    return ((JArray)source).ToBson();
+                case JTokenType.Integer:
+                    return BsonValue.Create(((JValue)source).Value);
+                case JTokenType.Float:
+                    return BsonValue.Create(((JValue)source).Value);
+                case JTokenType.String:
+                    return BsonValue.Create(((JValue)source).Value);
+                case JTokenType.Boolean:
+                    return BsonValue.Create(((JValue)source).Value);
+                case JTokenType.Null:
+                    return BsonNull.Value;
+                case JTokenType.Undefined:
+                    return BsonUndefined.Value;
+                case JTokenType.Date:
+                    return BsonValue.Create(((JValue)source).Value.ToString());
+                case JTokenType.Bytes:
+                    return BsonValue.Create(((JValue)source).Value);
+                case JTokenType.Guid:
+                    return BsonValue.Create(((JValue)source).Value.ToString());
+                case JTokenType.Uri:
+                    return BsonValue.Create(((JValue)source).Value.ToString());
+                case JTokenType.TimeSpan:
+                    return BsonValue.Create(((JValue)source).Value.ToString());
+            }
+
+            throw new NotSupportedException($"Cannot convert {source.GetType()} to Bson.");
+        }
+
+        public static JToken ToJson(this BsonValue source)
+        {
+            switch (source.BsonType)
+            {
+                case BsonType.Document:
+                    return source.AsBsonDocument.ToJson();
+                case BsonType.Array:
+                    return source.AsBsonArray.ToJson();
+                case BsonType.Double:
+                    return new JValue(source.AsDouble);
+                case BsonType.String:
+                    return new JValue(source.AsString);
+                case BsonType.Boolean:
+                    return new JValue(source.AsBoolean);
+                case BsonType.DateTime:
+                    return new JValue(source.ToUniversalTime());
+                case BsonType.Int32:
+                    return new JValue(source.AsInt32);
+                case BsonType.Int64:
+                    return new JValue(source.AsInt64);
+                case BsonType.Decimal128:
+                    return new JValue(source.AsDecimal);
+                case BsonType.Binary:
+                    return new JValue(source.AsBsonBinaryData.Bytes);
+                case BsonType.Null:
+                    return JValue.CreateNull();
+                case BsonType.Undefined:
+                    return JValue.CreateUndefined();
+            }
+
+            throw new NotSupportedException($"Cannot convert {source.GetType()} to Json.");
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonReader.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonReader.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using Orleans.Providers.MongoDB.Utils;
+using NewtonsoftJsonReader = Newtonsoft.Json.JsonReader;
+using NewtonsoftJsonToken = Newtonsoft.Json.JsonToken;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public sealed class BsonJsonReader : NewtonsoftJsonReader
+    {
+        private readonly IBsonReader bsonReader;
+
+        public BsonJsonReader(IBsonReader bsonReader)
+        {
+            Guard.NotNull(bsonReader, nameof(bsonReader));
+
+            this.bsonReader = bsonReader;
+        }
+
+        public override bool Read()
+        {
+            if (bsonReader.State == BsonReaderState.Initial ||
+                bsonReader.State == BsonReaderState.ScopeDocument ||
+                bsonReader.State == BsonReaderState.Type)
+            {
+                bsonReader.ReadBsonType();
+            }
+
+            if (bsonReader.State == BsonReaderState.Name)
+            {
+                SetToken(NewtonsoftJsonToken.PropertyName, bsonReader.ReadName().UnescapeBson());
+            }
+            else if (bsonReader.State == BsonReaderState.EndOfDocument)
+            {
+                SetToken(NewtonsoftJsonToken.EndObject);
+                bsonReader.ReadEndDocument();
+            }
+            else if (bsonReader.State == BsonReaderState.EndOfArray)
+            {
+                SetToken(NewtonsoftJsonToken.EndArray);
+                bsonReader.ReadEndArray();
+            }
+            else if (bsonReader.State == BsonReaderState.Value)
+            {
+                switch (bsonReader.CurrentBsonType)
+                {
+                    case BsonType.Document:
+                        SetToken(NewtonsoftJsonToken.StartObject);
+                        bsonReader.ReadStartDocument();
+                        break;
+                    case BsonType.Array:
+                        SetToken(NewtonsoftJsonToken.StartArray);
+                        bsonReader.ReadStartArray();
+                        break;
+                    case BsonType.Undefined:
+                        SetToken(NewtonsoftJsonToken.Undefined);
+                        bsonReader.ReadUndefined();
+                        break;
+                    case BsonType.Null:
+                        SetToken(NewtonsoftJsonToken.Null);
+                        bsonReader.ReadNull();
+                        break;
+                    case BsonType.String:
+                        SetToken(NewtonsoftJsonToken.String, bsonReader.ReadString());
+                        break;
+                    case BsonType.Binary:
+                        SetToken(NewtonsoftJsonToken.Bytes, bsonReader.ReadBinaryData().Bytes);
+                        break;
+                    case BsonType.Boolean:
+                        SetToken(NewtonsoftJsonToken.Boolean, bsonReader.ReadBoolean());
+                        break;
+                    case BsonType.DateTime:
+                        SetToken(NewtonsoftJsonToken.Date, bsonReader.ReadDateTime());
+                        break;
+                    case BsonType.Int32:
+                        SetToken(NewtonsoftJsonToken.Integer, bsonReader.ReadInt32());
+                        break;
+                    case BsonType.Int64:
+                        SetToken(NewtonsoftJsonToken.Integer, bsonReader.ReadInt64());
+                        break;
+                    case BsonType.Double:
+                        SetToken(NewtonsoftJsonToken.Float, bsonReader.ReadDouble());
+                        break;
+                    case BsonType.Decimal128:
+                        SetToken(NewtonsoftJsonToken.Float, Decimal128.ToDouble(bsonReader.ReadDecimal128()));
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            if (bsonReader.State == BsonReaderState.Initial)
+            {
+                return true;
+            }
+
+            return !bsonReader.IsAtEndOfFile();
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonSerializer.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonSerializer.cs
@@ -1,0 +1,33 @@
+﻿using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using Newtonsoft.Json;
+using Orleans.Providers.MongoDB.Utils;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public class BsonJsonSerializer<T> : ClassSerializerBase<T> where T : class
+    {
+        private readonly JsonSerializer serializer;
+
+        public BsonJsonSerializer(JsonSerializer serializer)
+        {
+            Guard.NotNull(serializer, nameof(serializer));
+
+            this.serializer = serializer;
+        }
+
+        protected override T DeserializeValue(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            var jsonReader = new BsonJsonReader(context.Reader);
+
+            return serializer.Deserialize<T>(jsonReader);
+        }
+
+        protected override void SerializeValue(BsonSerializationContext context, BsonSerializationArgs args, T value)
+        {
+            var jsonWriter = new BsonJsonWriter(context.Writer);
+
+            serializer.Serialize(jsonWriter, value);
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonWriter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/BsonJsonWriter.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using MongoDB.Bson.IO;
+using Orleans.Providers.MongoDB.Utils;
+using NewtonsoftJSonWriter = Newtonsoft.Json.JsonWriter;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public sealed class BsonJsonWriter : NewtonsoftJSonWriter
+    {
+        private readonly IBsonWriter bsonWriter;
+
+        public BsonJsonWriter(IBsonWriter bsonWriter)
+        {
+            Guard.NotNull(bsonWriter, nameof(bsonWriter));
+
+            this.bsonWriter = bsonWriter;
+        }
+
+        public override void WritePropertyName(string name)
+        {
+            bsonWriter.WriteName(name.EscapeJson());
+        }
+
+        public override void WritePropertyName(string name, bool escape)
+        {
+            bsonWriter.WriteName(name.EscapeJson());
+        }
+
+        public override void WriteStartArray()
+        {
+            bsonWriter.WriteStartArray();
+        }
+
+        public override void WriteEndArray()
+        {
+            bsonWriter.WriteEndArray();
+        }
+
+        public override void WriteStartObject()
+        {
+            bsonWriter.WriteStartDocument();
+        }
+
+        public override void WriteEndObject()
+        {
+            bsonWriter.WriteEndDocument();
+        }
+
+        public override void WriteNull()
+        {
+            bsonWriter.WriteNull();
+        }
+
+        public override void WriteUndefined()
+        {
+            bsonWriter.WriteUndefined();
+        }
+
+        public override void WriteValue(string value)
+        {
+            bsonWriter.WriteString(value);
+        }
+
+        public override void WriteValue(int value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(uint value)
+        {
+            bsonWriter.WriteInt32((int)value);
+        }
+
+        public override void WriteValue(long value)
+        {
+            bsonWriter.WriteInt64(value);
+        }
+
+        public override void WriteValue(ulong value)
+        {
+            bsonWriter.WriteInt64((long)value);
+        }
+
+        public override void WriteValue(float value)
+        {
+            bsonWriter.WriteDouble(value);
+        }
+
+        public override void WriteValue(double value)
+        {
+            bsonWriter.WriteDouble(value);
+        }
+
+        public override void WriteValue(bool value)
+        {
+            bsonWriter.WriteBoolean(value);
+        }
+
+        public override void WriteValue(short value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(ushort value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(char value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(byte value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(sbyte value)
+        {
+            bsonWriter.WriteInt32(value);
+        }
+
+        public override void WriteValue(decimal value)
+        {
+            bsonWriter.WriteDecimal128(value);
+        }
+
+        public override void WriteValue(DateTime value)
+        {
+            bsonWriter.WriteString(value.ToString());
+        }
+
+        public override void WriteValue(DateTimeOffset value)
+        {
+            bsonWriter.WriteString(value.ToString());
+        }
+
+        public override void WriteValue(byte[] value)
+        {
+            bsonWriter.WriteBytes(value);
+        }
+
+        public override void WriteValue(TimeSpan value)
+        {
+            bsonWriter.WriteString(value.ToString());
+        }
+
+        public override void WriteValue(Guid value)
+        {
+            bsonWriter.WriteString(value.ToString());
+        }
+
+        public override void WriteValue(Uri value)
+        {
+            bsonWriter.WriteString(value.ToString());
+        }
+
+        public override void Flush()
+        {
+            bsonWriter.Flush();
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/IMongoStorageCollection.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/IMongoStorageCollection.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public interface IMongoStorageCollection
+    {
+        Task Delete(string key);
+
+        Task<(string Etag, object Value)> Read(string key);
+
+        Task<string> Write(string key, object entityData, string etag);
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageCollection.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageCollection.cs
@@ -1,0 +1,75 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+using Orleans.Storage;
+using System;
+using System.Threading.Tasks;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public sealed class MongoStorageCollection<T> : IMongoStorageCollection
+    {
+        private static readonly UpdateOptions Upsert = new UpdateOptions { IsUpsert = true };
+        private static readonly SortDefinitionBuilder<StorageDocument<T>> Sort = Builders<StorageDocument<T>>.Sort;
+        private static readonly UpdateDefinitionBuilder<StorageDocument<T>> Update = Builders<StorageDocument<T>>.Update;
+        private static readonly FilterDefinitionBuilder<StorageDocument<T>> Filter = Builders<StorageDocument<T>>.Filter;
+        private static readonly IndexKeysDefinitionBuilder<StorageDocument<T>> Index = Builders<StorageDocument<T>>.IndexKeys;
+        private static readonly ProjectionDefinitionBuilder<StorageDocument<T>> Project = Builders<StorageDocument<T>>.Projection;
+        private readonly IMongoCollection<StorageDocument<T>> collection;
+
+        public MongoStorageCollection(IMongoDatabase database, string collectionName)
+        {
+            collection = database.GetCollection<StorageDocument<T>>(collectionName);
+        }
+
+        public Task Delete(string key)
+        {
+            return collection.DeleteManyAsync(x => x.Key == key);
+        }
+
+        public async Task<(string Etag, object Value)> Read(string key)
+        {
+            var existing =
+                await collection.Find(x => x.Key == key)
+                    .FirstOrDefaultAsync();
+
+            if (existing != null)
+            {
+                return (existing.Etag, existing.State);
+            }
+
+            return (null, null);
+        }
+
+        public async Task<string> Write(string key, object entityData, string etag)
+        {
+            var newETag = Guid.NewGuid().ToString();
+
+            try
+            {
+                await collection.UpdateOneAsync(x => x.Key == key && x.Etag == etag,
+                    Update
+                        .Set(x => x.Etag, newETag)
+                        .Set(x => x.State, (T)entityData),
+                    Upsert);
+            }
+            catch (MongoWriteException ex)
+            {
+                if (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
+                {
+                    var existingEtag =
+                        await collection.Find(x => x.Key == key)
+                            .Project<BsonDocument>(Project.Exclude("State")).FirstOrDefaultAsync();
+
+                    if (existingEtag != null && existingEtag.Contains("Etag"))
+                    {
+                        throw new InconsistentStateException(existingEtag["Etag"].AsString, etag, ex);
+                    }
+                }
+
+                throw;
+            }
+
+            return newETag;
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageProviderV2.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageProviderV2.cs
@@ -49,6 +49,8 @@ namespace Orleans.Providers.MongoDB.StorageProviders.V2
             var mongoCollectionPrefix = config.GetProperty(CollectionPrefixProperty, string.Empty);
             var mongoDatabaseName = config.GetProperty(DatabaseNameProperty, string.Empty);
 
+            BsonJsonConvention.Register(serializer);
+
             prefix = mongoCollectionPrefix;
 
             var client = MongoClientPool.Instance(mongoConnectionString);

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageProviderV2.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/MongoStorageProviderV2.cs
@@ -1,0 +1,161 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using Newtonsoft.Json;
+using Orleans.Providers.MongoDB.Utils;
+using Orleans.Runtime;
+using Orleans.Serialization;
+using Orleans.Storage;
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public class MongoStorageProviderV2 : IStorageProvider
+    {
+        public const string ConnectionStringProperty = "ConnectionString";
+        public const string CollectionPrefixProperty = "CollectionPrefix";
+        public const string DatabaseNameProperty = "DatabaseProperty";
+        public const string SerializerSettingsProperty = "SerializerSettings";
+        private readonly ILogger<MongoStorageProviderV2> logger;
+        private readonly ConcurrentDictionary<(Type, string), IMongoStorageCollection> collections = new ConcurrentDictionary<(Type, string), IMongoStorageCollection>();
+        private IMongoDatabase database;
+        private string prefix;
+        private JsonSerializerSettings serializerSettings;
+        private JsonSerializer serializer;
+        private SerializationManager serializationManager;
+
+        public Logger Log { get; private set; }
+
+        public string Name { get; private set; }
+
+        public MongoStorageProviderV2(ILogger<MongoStorageProviderV2> logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <inheritdoc />
+        public Task Init(string name, IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {
+            Name = name;
+
+            serializationManager = providerRuntime.ServiceProvider.GetRequiredService<SerializationManager>();
+            serializerSettings = ReturnSerializerSettings(providerRuntime, config);
+            serializer = JsonSerializer.Create(serializerSettings);
+
+            var mongoConnectionString = config.GetProperty(ConnectionStringProperty, string.Empty);
+            var mongoCollectionPrefix = config.GetProperty(CollectionPrefixProperty, string.Empty);
+            var mongoDatabaseName = config.GetProperty(DatabaseNameProperty, string.Empty);
+
+            prefix = mongoCollectionPrefix;
+
+            var client = MongoClientPool.Instance(mongoConnectionString);
+
+            database = client.GetDatabase(mongoDatabaseName);
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public async Task ClearStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            var grainName = ReturnGrainName(grainType, grainReference);
+            var grainKey = grainReference.ToKeyString();
+
+            try
+            {
+                var collection = GetCollection(typeof(object), grainType, grainReference);
+
+                await collection.Delete(grainKey);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError((int)MongoProviderErrorCode.StorageProvider_Deleting, $"Error Deleting: GrainType={grainType} GrainId={grainKey} ETag={grainState.ETag} from Collection={grainName} Exception={ex.Message}", ex);
+                throw;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task WriteStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            var grainName = ReturnGrainName(grainType, grainReference);
+            var grainKey = grainReference.ToKeyString();
+
+            try
+            {
+                IMongoStorageCollection collection;
+
+                if (grainState.State != null)
+                {
+                    collection = GetCollection(grainState.State.GetType(), grainType, grainReference);
+                }
+                else
+                {
+                    collection = GetCollection(typeof(object), grainType, grainReference);
+                }
+
+                grainState.ETag = await collection.Write(grainKey, grainState.State, grainState.ETag);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError((int)MongoProviderErrorCode.StorageProvider_Writing, $"Error Writing: GrainType={grainType} GrainId={grainKey} ETag={grainState.ETag} to Collection={grainName} Exception={ex.Message}", ex);
+                throw;
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task ReadStateAsync(string grainType, GrainReference grainReference, IGrainState grainState)
+        {
+            if (grainState.State == null)
+            {
+                throw new InvalidOperationException("Can only read to valid grain state. Initialize with default value.");
+            }
+
+            var grainTypeName = ReturnGrainName(grainType, grainReference);
+            var grainKey = grainReference.ToKeyString();
+
+            try
+            {
+                var collection = GetCollection(grainState.State.GetType(), grainType, grainReference);
+
+                var (Etag, Value) = await collection.Read(grainKey);
+
+                if (Value != null)
+                {
+                    grainState.State = Value;
+                    grainState.ETag = Etag;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError((int)MongoProviderErrorCode.StorageProvider_Reading, $"Error Reading: GrainType={grainType} GrainId={grainKey} ETag={grainState.ETag} from Collection={grainTypeName} Exception={ex.Message}", ex);
+                throw;
+            }
+        }
+
+        /// <inheritdoc />
+        public Task Close()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected virtual JsonSerializerSettings ReturnSerializerSettings(IProviderRuntime providerRuntime, IProviderConfiguration config)
+        {
+            return OrleansJsonSerializer.UpdateSerializerSettings(OrleansJsonSerializer.GetDefaultSerializerSettings(serializationManager, providerRuntime.GrainFactory), config);
+        }
+
+        protected virtual string ReturnGrainName(string grainType, GrainReference grainReference)
+        {
+            return grainType.Split('.', '+').Last();
+        }
+
+        private IMongoStorageCollection GetCollection(Type type, string grainName, GrainReference grainReference)
+        {
+            var key = (type, grainName);
+
+            return collections.GetOrAdd(key, x => (IMongoStorageCollection)Activator.CreateInstance(typeof(MongoStorageCollection<>).MakeGenericType(type), database, prefix + grainName));
+        }
+    }
+}

--- a/Orleans.Providers.MongoDB/StorageProviders/V2/StorageDocument.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/V2/StorageDocument.cs
@@ -1,0 +1,22 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Orleans.Providers.MongoDB.StorageProviders.V2
+{
+    public sealed class StorageDocument<T>
+    {
+        [BsonId]
+        [BsonElement]
+        [BsonRepresentation(BsonType.String)]
+        public string Key { get; set; }
+
+        [BsonRequired]
+        [BsonElement]
+        [BsonJson]
+        public T State { get; set; }
+
+        [BsonRequired]
+        [BsonElement]
+        public string Etag { get; set; }
+    }
+}


### PR DESCRIPTION
Experimental V2 Storage provider that uses the JsonWriter/BsonWriter directly for serialization and therefore avoids to read to BsonDocument and JToken => A LOT less allocations and about 40% faster in my tests. Have used the same approach in another project.

Not backward compatible anymore.

Needs Review.

Todo: Add Tests