### PR TITLE
Make the provider configurable to handle C# DateTime type's serialization.

### DIFF
--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
@@ -7,6 +7,8 @@ namespace Orleans.Providers.MongoDB.Configuration
     /// </summary>
     public class MongoDBGrainStorageOptions : MongoDBOptions
     {
+        public bool DateTimeStoredAsString { get; set; } = true;
+
         public MongoDBGrainStorageOptions()
         {
             CollectionPrefix = "Grains";

--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
@@ -8,6 +8,7 @@ namespace Orleans.Providers.MongoDB.Configuration
     public class MongoDBGrainStorageOptions : MongoDBOptions
     {
         public bool DateTimeStoredAsString { get; set; } = true;
+        public bool DateTimeDeserializedAsLocal { get; set; } = false;
 
         public MongoDBGrainStorageOptions()
         {

--- a/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
@@ -18,13 +18,13 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return result;
         }
 
-        public static JObject ToJToken(this BsonDocument source)
+        public static JObject ToJToken(this BsonDocument source, bool dateTimeAsLocal = false)
         {
             var result = new JObject();
 
             foreach (var property in source)
             {
-                result.Add(property.Name.UnescapeBson(), property.Value.ToJToken());
+                result.Add(property.Name.UnescapeBson(), property.Value.ToJToken(dateTimeAsLocal));
             }
 
             return result;
@@ -42,13 +42,13 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return result;
         }
 
-        public static JArray ToJToken(this BsonArray source)
+        public static JArray ToJToken(this BsonArray source, bool dateTimeAsLocal = false)
         {
             var result = new JArray();
 
             foreach (var item in source)
             {
-                result.Add(item.ToJToken());
+                result.Add(item.ToJToken(dateTimeAsLocal));
             }
 
             return result;
@@ -104,14 +104,14 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             throw new NotSupportedException($"Cannot convert {source.GetType()} to Bson.");
         }
 
-        public static JToken ToJToken(this BsonValue source)
+        public static JToken ToJToken(this BsonValue source,bool dateTimeAsLocal = false)
         {
             switch (source.BsonType)
             {
                 case BsonType.Document:
-                    return source.AsBsonDocument.ToJToken();
+                    return source.AsBsonDocument.ToJToken(dateTimeAsLocal);
                 case BsonType.Array:
-                    return source.AsBsonArray.ToJToken();
+                    return source.AsBsonArray.ToJToken(dateTimeAsLocal);
                 case BsonType.Double:
                     return new JValue(source.AsDouble);
                 case BsonType.String:
@@ -119,7 +119,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                 case BsonType.Boolean:
                     return new JValue(source.AsBoolean);
                 case BsonType.DateTime:
-                    return new JValue(source.ToUniversalTime());
+                    return new JValue(dateTimeAsLocal ? source.ToLocalTime() : source.ToUniversalTime());
                 case BsonType.Int32:
                     return new JValue(source.AsInt32);
                 case BsonType.Int64:

--- a/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
@@ -119,7 +119,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                 case BsonType.Boolean:
                     return new JValue(source.AsBoolean);
                 case BsonType.DateTime:
-                    return new JValue(source.ToLocalTime());
+                    return new JValue(source.ToUniversalTime());
                 case BsonType.Int32:
                     return new JValue(source.AsInt32);
                 case BsonType.Int64:

--- a/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
@@ -88,7 +88,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
 
                         if (value is DateTime dateTime)
                         {
-                            return dateTime.ToString("yyyy-MM-ddTHH:mm:ssK");
+                            return BsonValue.Create(dateTime);
                         }
                         else if (value is DateTimeOffset dateTimeOffset)
                         {
@@ -119,7 +119,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                 case BsonType.Boolean:
                     return new JValue(source.AsBoolean);
                 case BsonType.DateTime:
-                    return new JValue(source.ToUniversalTime());
+                    return new JValue(source.ToLocalTime());
                 case BsonType.Int32:
                     return new JValue(source.AsInt32);
                 case BsonType.Int64:

--- a/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
@@ -6,13 +6,13 @@ namespace Orleans.Providers.MongoDB.StorageProviders
 {
     public static class JsonBsonConverter
     {
-        public static BsonDocument ToBson(this JObject source)
+        public static BsonDocument ToBson(this JObject source,bool dateTimeAsString = true)
         {
             var result = new BsonDocument();
 
             foreach (var property in source)
             {
-                result.Add(property.Key.EscapeJson(), property.Value.ToBson());
+                result.Add(property.Key.EscapeJson(), property.Value.ToBson(dateTimeAsString));
             }
 
             return result;
@@ -30,13 +30,13 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return result;
         }
 
-        public static BsonArray ToBson(this JArray source)
+        public static BsonArray ToBson(this JArray source, bool dateTimeAsString = true)
         {
             var result = new BsonArray();
 
             foreach (var item in source)
             {
-                result.Add(item.ToBson());
+                result.Add(item.ToBson(dateTimeAsString));
             }
 
             return result;
@@ -54,14 +54,14 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return result;
         }
 
-        public static BsonValue ToBson(this JToken source)
+        public static BsonValue ToBson(this JToken source, bool dateTimeAsString = true)
         {
             switch (source.Type)
             {
                 case JTokenType.Object:
-                    return ((JObject)source).ToBson();
+                    return ((JObject)source).ToBson(dateTimeAsString);
                 case JTokenType.Array:
-                    return ((JArray)source).ToBson();
+                    return ((JArray)source).ToBson(dateTimeAsString);
                 case JTokenType.Integer:
                     return BsonValue.Create(((JValue)source).Value);
                 case JTokenType.Float:
@@ -88,7 +88,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
 
                         if (value is DateTime dateTime)
                         {
-                            return BsonValue.Create(dateTime);
+                            return dateTimeAsString ? dateTime.ToString("yyyy-MM-ddTHH:mm:ssK") : BsonValue.Create(dateTime);
                         }
                         else if (value is DateTimeOffset dateTimeOffset)
                         {

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -82,13 +82,13 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                     {
                         grainState.ETag = existing[FieldEtag].AsString;
 
-                        serializer.Deserialize(grainState, existing[FieldDoc].AsBsonDocument.ToJToken());
+                        serializer.Deserialize(grainState, existing[FieldDoc].AsBsonDocument.ToJToken(this.options.DateTimeDeserializedAsLocal));
                     }
                     else
                     {
                         existing.Remove(FieldId);
 
-                        serializer.Deserialize(grainState, existing.ToJToken());
+                        serializer.Deserialize(grainState, existing.ToJToken(this.options.DateTimeDeserializedAsLocal));
                     }
                 }
             });

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -104,8 +104,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                 var grainData = serializer.Serialize(grainState);
 
                 var etag = grainState.ETag;
-
-                var newData = grainData.ToBson();
+                var newData = grainData.ToBson(this.options.DateTimeStoredAsString);
                 var newETag = Guid.NewGuid().ToString();
 
                 try


### PR DESCRIPTION
1.Make the provider configurable to store C# DataTime members as Date type in MongoDB.
2.Make the provider configurable to deserialize Date type in MongoDB as  C# local time or universal time.
