### PR TITLE
allow setting database from mongodb connection string

### DIFF
--- a/Orleans.Providers.MongoDB/Configuration/MongoDBOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBOptions.cs
@@ -47,7 +47,7 @@ namespace Orleans.Providers.MongoDB.Configuration
 
                 try
                 {
-                    var mongoUrl = new MongoUrlBuilder(originalConnectionString) { DatabaseName = null };
+                    var mongoUrl = new MongoUrlBuilder(originalConnectionString);
 
                     ConnectionString = mongoUrl.ToMongoUrl().ToString();
                 }


### PR DESCRIPTION
Currently when we try to use MongoDBOptions to create a mongodb client, it will remove the database information from the connection string by setting Database = null, it is fine if the monogdb database does not need authentication. However if authentication is needed, mongodb will try to login to "admin" database, and it may result an authentication failure.

ref: https://docs.mongodb.com/manual/reference/connection-string/

"/database

Optional. The name of the database to authenticate if the connection string includes authentication credentials in the form of username:password@. If /database is not specified and the connection string includes credentials, the driver will authenticate to the admin database. "