### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Just use the silo builder:
 
 ```csharp
 var silo = new SiloHostBuilder()
-    .AddMongoDBGrainStorage(options =>
+    .AddMongoDBGrainStorage("grains-storage-provider-name"
+    options =>
     {
         options.DatabaseName = dbName;
         options.CreateShardKeyForCosmos = createShardKey;


### PR DESCRIPTION
This is a small documentation update. To make it more clear and easy to use.
MongoDBSiloExtensions.AddMongoDBGrainStorage method (and overloaded versions) require name parameter.