### PR TITLE
Update MongoDB.Driver reference to version 2.11

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.1.7" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.7" />
-    <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.11.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As discussed at https://jira.mongodb.org/browse/CSHARP-2592 , the `MongoDB.Driver` package version 2.10.x targets only `netstandard1.5`, while it brings in a lot of extension packages providing with APIs which are missing from .net standard 1.x.
Even when a project targets .NET 5.0, a ton of the unused packages are still restored, and it may be harmful to some analytic tools that use reflection.
Additionally, as described in the issue link, Microsoft recommends the libraries to target .net standard 2.0+ and regard .net standard 1.x as deprecated.
`MongoDB.Driver` version 2.11 was the initial version that targets .net standard 2.0, which means when restored in a modern .NET Core or .NET 5 project, the build that targets .net standard 2.0 would be preferred, that gets rid of some build and analytic problems.