### PR TITLE
Adds the ability to use a different strategy for creating keys

### DIFF
--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
@@ -2,6 +2,7 @@
 
 using Newtonsoft.Json;
 using System;
+using Orleans.Runtime;
 
 namespace Orleans.Providers.MongoDB.Configuration
 {
@@ -16,5 +17,25 @@ namespace Orleans.Providers.MongoDB.Configuration
         }
 
         public Action<JsonSerializerSettings> ConfigureJsonSerializerSettings { get; set; }
+
+        /// <summary>
+        /// The key generation strategy used by the storage provider. It defaults to calling ToKeyString
+        /// in the grain reference.
+        /// </summary>
+        public GrainStorageKeyGenerator KeyGenerator { get; set; } = x => x.ToKeyString();
+
+        internal override void Validate(string name = null)
+        {
+            base.Validate(name);
+
+            if (KeyGenerator == null)
+                throw new OrleansConfigurationException($"{nameof(KeyGenerator)} is required and cannot be null.");
+
+        }
     }
+
+    /// <summary>
+    /// Delegate representing a strategy for generating the key of the persisted state in MongoDB.
+    /// </summary>
+    public delegate string GrainStorageKeyGenerator(GrainReference grainReference);
 }

--- a/Orleans.Providers.MongoDB/Configuration/MongoDBOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBOptions.cs
@@ -29,7 +29,7 @@ namespace Orleans.Providers.MongoDB.Configuration
         /// </summary>
         public bool CreateShardKeyForCosmos { get; set; }
 
-        internal void Validate(string name = null)
+        internal virtual void Validate(string name = null)
         {
             var typeName = GetType().Name;
 

--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <Authors>laredoza,sebastianstehle</Authors>
     <Company>Orleans.Providers.MongoDB</Company>
     <Description>A MongoDb implementation of the Orleans Providers. This includes custering (IMembershipTable and IGatewayListProvider), reminders (IReminderTable) and storage providers (IGrainStorage).</Description>

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -74,7 +74,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return DoAndLog(nameof(ReadStateAsync), async () =>
             {
                 var grainCollection = GetCollection(grainType);
-                var grainKey = grainReference.ToKeyString();
+                var grainKey = this.options.KeyGenerator(grainReference);
 
                 var existing =
                     await grainCollection.Find(Filter.Eq(FieldId, grainKey))
@@ -105,7 +105,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return DoAndLog(nameof(WriteStateAsync), async () =>
             {
                 var grainCollection = GetCollection(grainType);
-                var grainKey = grainReference.ToKeyString();
+                var grainKey = options.KeyGenerator(grainReference);
 
                 var grainData = serializer.Serialize(grainState);
 
@@ -172,7 +172,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             return DoAndLog(nameof(ClearStateAsync), () =>
             {
                 var grainCollection = GetCollection(grainType);
-                var grainKey = grainReference.ToKeyString();
+                var grainKey = options.KeyGenerator(grainReference);
 
                 grainState.RecordExists = false;
 


### PR DESCRIPTION
This PR adds a way of customizing what the persisted key looks like. For a particular use case I want to keep just the grain string key as ID, rather than the entire reference, and this option would be handy.