### PR TITLE
Added config overload for UseMongoDBClient and AddMongoDBClient

### DIFF
--- a/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
@@ -1,18 +1,20 @@
-﻿using System;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 using Orleans.Hosting;
 using Orleans.Messaging;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
+using System;
 
+// ReSharper disable InconsistentNaming
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable CheckNamespace
 
 namespace Orleans
 {
     /// <summary>
-    /// Extension methods for configuration classes specific to OrleansMongoUtils.dll 
+    /// Extension methods for configuration classes specific to Orleans.Providers.MongoDB.dll 
     /// </summary>
     public static class MongoDBClientExtensions
     {
@@ -26,10 +28,19 @@ namespace Orleans
         }
 
         /// <summary>
+        /// Configure silo to use MongoDb with a passed in connection string.
+        /// </summary>
+        /// <param name="configureClientSettings">The configuration delegate to configure the <see cref="MongoClientSettings"/>.</param>
+        public static IClientBuilder UseMongoDBClient(this IClientBuilder builder, ActionRef<MongoClientSettings> configureClientSettings)
+        {
+            return builder.ConfigureServices(services => services.AddMongoDBClient(configureClientSettings));
+        }
+
+        /// <summary>
         /// Configure client to use MongoGatewayListProvider
         /// </summary>
         public static IClientBuilder UseMongoDBClustering(this IClientBuilder builder,
-            Action<MongoDBGatewayListProviderOptions> configurator = null)
+                Action<MongoDBGatewayListProviderOptions> configurator = null)
         {
             return builder.ConfigureServices(services => services.AddMongoDBGatewayListProvider(configurator));
         }

--- a/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using Orleans.Hosting;
 using Orleans.Messaging;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
-using System;
+
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable AccessToStaticMemberViaDerivedType

--- a/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBClientExtensions.cs
@@ -30,17 +30,19 @@ namespace Orleans
         /// <summary>
         /// Configure silo to use MongoDb with a passed in connection string.
         /// </summary>
-        /// <param name="configureClientSettings">The configuration delegate to configure the <see cref="MongoClientSettings"/>.</param>
-        public static IClientBuilder UseMongoDBClient(this IClientBuilder builder, ActionRef<MongoClientSettings> configureClientSettings)
+        /// <param name="builder">The builder.</param>
+        /// <param name="settingsFactory">The settings factory.</param>
+        /// <returns></returns>
+        public static IClientBuilder UseMongoDBClient(this IClientBuilder builder, Func<IServiceProvider, MongoClientSettings> settingsFactory)
         {
-            return builder.ConfigureServices(services => services.AddMongoDBClient(configureClientSettings));
+            return builder.ConfigureServices(services => services.AddMongoDBClient(settingsFactory));
         }
 
         /// <summary>
         /// Configure client to use MongoGatewayListProvider
         /// </summary>
         public static IClientBuilder UseMongoDBClustering(this IClientBuilder builder,
-                Action<MongoDBGatewayListProviderOptions> configurator = null)
+            Action<MongoDBGatewayListProviderOptions> configurator = null)
         {
             return builder.ConfigureServices(services => services.AddMongoDBGatewayListProvider(configurator));
         }

--- a/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Orleans.Configuration;
-using Orleans.Hosting;
 using Orleans.Providers;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
@@ -13,7 +13,7 @@ using Orleans.Providers.MongoDB.StorageProviders;
 using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Runtime;
 using Orleans.Storage;
-using System;
+
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable CheckNamespace
 // ReSharper disable InconsistentNaming

--- a/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
@@ -37,10 +37,12 @@ namespace Orleans.Hosting
         /// <summary>
         /// Configure silo to use MongoDb with a passed in connection string.
         /// </summary>
-        /// <param name="configureClientSettings">The configuration delegate to configure the <see cref="MongoClientSettings"/>.</param>
-        public static ISiloBuilder UseMongoDBClient(this ISiloBuilder builder, ActionRef<MongoClientSettings> configureClientSettings)
+        /// <param name="builder">The builder.</param>
+        /// <param name="settingsFactory">The settings factory.</param>
+        /// <returns></returns>
+        public static ISiloBuilder UseMongoDBClient(this ISiloBuilder builder, Func<IServiceProvider, MongoClientSettings> settingsFactory)
         {
-            return builder.ConfigureServices(services => services.AddMongoDBClient(configureClientSettings));
+            return builder.ConfigureServices(services => services.AddMongoDBClient(settingsFactory));
         }
 
         /// <summary>

--- a/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
+++ b/Orleans.Providers.MongoDB/MongoDBSiloExtensions.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using MongoDB.Driver;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers;
@@ -13,9 +13,10 @@ using Orleans.Providers.MongoDB.StorageProviders;
 using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Runtime;
 using Orleans.Storage;
-
+using System;
 // ReSharper disable AccessToStaticMemberViaDerivedType
 // ReSharper disable CheckNamespace
+// ReSharper disable InconsistentNaming
 
 namespace Orleans.Hosting
 {
@@ -34,10 +35,19 @@ namespace Orleans.Hosting
         }
 
         /// <summary>
+        /// Configure silo to use MongoDb with a passed in connection string.
+        /// </summary>
+        /// <param name="configureClientSettings">The configuration delegate to configure the <see cref="MongoClientSettings"/>.</param>
+        public static ISiloBuilder UseMongoDBClient(this ISiloBuilder builder, ActionRef<MongoClientSettings> configureClientSettings)
+        {
+            return builder.ConfigureServices(services => services.AddMongoDBClient(configureClientSettings));
+        }
+
+        /// <summary>
         /// Configure ISiloBuilder to use MongoReminderTable.
         /// </summary>
         public static ISiloBuilder UseMongoDBReminders(this ISiloBuilder builder,
-            Action<MongoDBRemindersOptions> configurator = null)
+                Action<MongoDBRemindersOptions> configurator = null)
         {
             return builder.ConfigureServices(services => services.AddMongoDBReminders(configurator));
         }

--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net7.0</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/ServiceCollectionExtensions.cs
+++ b/Orleans.Providers.MongoDB/ServiceCollectionExtensions.cs
@@ -1,9 +1,14 @@
 ﻿using MongoDB.Driver;
 using Orleans.Providers.MongoDB.Utils;
+using System;
+// ReSharper disable InconsistentNaming
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions
+  // "by-ref" Action<T> delegate
+  public delegate void ActionRef<T>(ref T item);
+
+  public static class ServiceCollectionExtensions
     {
         /// <summary>
         /// Configure silo to use MongoDb with a passed in connection string.
@@ -12,6 +17,26 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddMongoDBClient(this IServiceCollection services, string connectionString)
         {
             services.AddSingleton<IMongoClient>(c => new MongoClient(connectionString));
+            services.AddSingleton<IMongoClientFactory, DefaultMongoClientFactory>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Configure silo to use MongoDb with a passed in connection string.
+        /// </summary>
+        /// <param name="services">The services.</param>
+        /// <param name="configureClientSettings">The configuration delegate to configure the <see cref="MongoClientSettings"/>.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddMongoDBClient(this IServiceCollection services, ActionRef<MongoClientSettings> configureClientSettings)
+        {
+            if (configureClientSettings == null) 
+              throw new ArgumentNullException(nameof(configureClientSettings));
+            
+            var settings = new MongoClientSettings();
+            configureClientSettings(ref settings);
+
+            services.AddSingleton<IMongoClient>(c => new MongoClient(settings));
             services.AddSingleton<IMongoClientFactory, DefaultMongoClientFactory>();
 
             return services;

--- a/Orleans.Providers.MongoDB/ServiceCollectionExtensions.cs
+++ b/Orleans.Providers.MongoDB/ServiceCollectionExtensions.cs
@@ -13,18 +13,15 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configure silo to use MongoDb with a passed in connection string.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <returns></returns>
         public static IServiceCollection AddMongoDBClient(this IServiceCollection services, string connectionString)
         {
-            services.TryAddSingleton<IMongoClient>(c => new MongoClient(connectionString));
-            services.TryAddSingleton<IMongoClientFactory, DefaultMongoClientFactory>();
-
-            return services;
+            return services.AddMongoDBClient(provider => MongoClientSettings.FromConnectionString(connectionString));
         }
 
         /// <summary>
         /// Configure silo to use MongoDb with a passed in connection string.
         /// </summary>
-        /// <param name="services">The services.</param>
         /// <param name="settingsFactory">The settings factory.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">settingsFactory</exception>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ var client = new ClientBuilder()
 
 as an alternative you can also implement the IMongoClientFactory interface and override the client names with options.
 
+There is also an overload of ```UseMongoDBClient()``` that takes a configuration delegate which gives you access to all MongoDB connection settings individually. This is especially useful, if you need to separate network settings and credentials into different configuration variables, as shown below.
+
+```csharp
+[...]
+  .UseMongoDBClient((ref MongoClientSettings settings) =>
+    {
+      var connectionString = config["Orleans:MongoDb:ConnectionString"];
+      var db = config["Orleans:MongoDb:AuthDatabase"];
+      var user = config["Orleans:MongoDb:User"];
+      var pw = config["Orleans:MongoDb:Password"];
+
+      settings = MongoClientSettings.FromConnectionString(connectionString);
+            
+      settings.Credential = MongoCredential.CreateCredential(db, user, pw);
+    })
+[...]
+```
+
+
+
+
 ### Membership
 
 Use the client builder to setup mongo db:

--- a/README.md
+++ b/README.md
@@ -49,20 +49,18 @@ var client = new ClientBuilder()
 
 as an alternative you can also implement the IMongoClientFactory interface and override the client names with options.
 
-There is also an overload of ```UseMongoDBClient()``` that takes a configuration delegate which gives you access to all MongoDB connection settings individually. This is especially useful, if you need to separate network settings and credentials into different configuration variables, as shown below.
+There is also an overload of ```UseMongoDBClient()``` that takes a ```Func<IServiceProvider, MongoClientSettings>``` which allows you specify all MongoDB connection settings individually. This is especially useful, if you need to separate network settings and credentials into different configuration variables, or if you want to bind to an ```IOptions<T>``` configuration as shown below.
 
 ```csharp
 [...]
-  .UseMongoDBClient((ref MongoClientSettings settings) =>
+  .UseMongoDBClient(provider =>
     {
-      var connectionString = config["Orleans:MongoDb:ConnectionString"];
-      var db = config["Orleans:MongoDb:AuthDatabase"];
-      var user = config["Orleans:MongoDb:User"];
-      var pw = config["Orleans:MongoDb:Password"];
+      var cfg = provider.GetRequiredService<IOptions<MyMongoDbConfiguration>>();
 
-      settings = MongoClientSettings.FromConnectionString(connectionString);
-            
-      settings.Credential = MongoCredential.CreateCredential(db, user, pw);
+      var settings = MongoClientSettings.FromConnectionString(cfg.Value.ConnectionString);
+      settings.Credential = MongoCredential.CreateCredential(cfg.Value.AuthDatabase, cfg.Value.UserName, cfg.Value.Password);
+
+      return settings;
     })
 [...]
 ```


### PR DESCRIPTION
### Problem:
When deploying a containerized application to, e.g., a Kubernetes cluster, chances are that different MongoDb settings come from different sources at deploy time.
Database names might be set by the developer, network settings (like server names, ports, tls, etc) will be set by an operator or devops engineer and credentials will be pulled from a vault.

This is really hard to achieve, if everything is mangled into one big connection string.

### Proposed solution:
I added overloads for the extension methods ```UseMongoDBClient()``` and ```AddMongoDBClient()``` that take a configuration delegate which gives the user access to all MongoDB connection settings individually. 

This allows code like this, where different parts of the connection settings are pulled from different configuration sources:

```csharp
[...]
  .UseMongoDBClient((ref MongoClientSettings settings) =>
    {
      var connectionString = config["Orleans:MongoDb:ConnectionString"];
      var db = config["Orleans:MongoDb:AuthDatabase"];
      var user = config["Orleans:MongoDb:User"];
      var pw = config["Orleans:MongoDb:Password"];

      settings = MongoClientSettings.FromConnectionString(connectionString);
            
      settings.Credential = MongoCredential.CreateCredential(db, user, pw);
    })
[...]
```



Edit (sidenote): We do follow the [semver](https://semver.org/) rules, don't we? I changed the version to 7.2.0 in accordance with rule 2, but of course I'm open for discussion.

