### PR TITLE
#124 Unique constraint violations are not propagated

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net7.0</TargetFrameworks>
-    <Version>7.4.0</Version>
+    <Version>7.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/Utils/MongoExtensions.cs
+++ b/Orleans.Providers.MongoDB/Utils/MongoExtensions.cs
@@ -1,4 +1,5 @@
-﻿using MongoDB.Driver;
+﻿using System;
+using MongoDB.Driver;
 using Orleans.Providers.MongoDB.Configuration;
 
 namespace Orleans.Providers.MongoDB.Utils
@@ -11,10 +12,14 @@ namespace Orleans.Providers.MongoDB.Utils
             {
                 return true;
             }
-            if (ex is MongoWriteException w && w.WriteError.Category == ServerErrorCategory.DuplicateKey)
+
+            if (ex is MongoWriteException w
+                && w.WriteError.Category == ServerErrorCategory.DuplicateKey
+                && w.WriteError.Message.Contains("index: _id_ ", StringComparison.Ordinal))
             {
                 return true;
             }
+
             return false;
         }
 

--- a/Test/GrainInterfaces/IConstrainedGrain.cs
+++ b/Test/GrainInterfaces/IConstrainedGrain.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Orleans.Providers.MongoDB.Test.GrainInterfaces
+{
+    public interface IConstrainedGrain : IGrainWithIntegerKey
+    {
+        Task SetName(string name);
+    }
+}

--- a/Test/Grains/ConstrainedGrain.cs
+++ b/Test/Grains/ConstrainedGrain.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Orleans.Providers.MongoDB.Test.GrainInterfaces;
+using Orleans.Runtime;
+
+namespace Orleans.Providers.MongoDB.Test.Grains
+{
+    internal class ConstrainedGrain : Grain, IConstrainedGrain
+    {
+        private readonly IPersistentState<ConstrainedGrainState> state;
+
+        public ConstrainedGrain([PersistentState(nameof(ConstrainedGrain), "MongoDBStore")] IPersistentState<ConstrainedGrainState> state)
+        {
+            this.state = state;
+        }
+
+        public async Task SetName(string name)
+        {
+            state.State.Name = name;
+
+            try
+            {
+                await state.WriteStateAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new ProviderStateException(ex.Message);
+            }
+        }
+    }
+}

--- a/Test/Grains/ConstrainedGrainState.cs
+++ b/Test/Grains/ConstrainedGrainState.cs
@@ -1,0 +1,7 @@
+﻿namespace Orleans.Providers.MongoDB.Test.Grains
+{
+    public class ConstrainedGrainState
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Test/Host/Program.cs
+++ b/Test/Host/Program.cs
@@ -10,12 +10,14 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Driver;
 using Newtonsoft.Json;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Providers.MongoDB.Test.GrainInterfaces;
+using Orleans.Providers.MongoDB.Test.Grains;
 using Orleans.Runtime;
 
 namespace Orleans.Providers.MongoDB.Test.Host
@@ -87,6 +89,8 @@ namespace Orleans.Providers.MongoDB.Test.Host
 
             await host.StartAsync();
 
+            await CreateConstraints(host.Services.GetRequiredService<IMongoClient>());
+
             var clientHost = new HostBuilder()
                 .UseOrleansClient((ctx, clientBuilder) => clientBuilder
                     .UseMongoDBClient(mongoRunner.ConnectionString)
@@ -121,9 +125,28 @@ namespace Orleans.Providers.MongoDB.Test.Host
             await TestState(client);
             await TestStateWithCollections(client);
 
+            await TestStateConstraints(client);
+
             Console.ReadKey();
 
             await host.StopAsync();
+        }
+
+        private static async Task CreateConstraints(IMongoClient mongoClient)
+        {
+            var collection = mongoClient.GetDatabase("OrleansTestApp")
+                .GetCollection<ConstrainedGrainState>("GrainsConstrainedGrain");
+
+            var indexBuilder = Builders<ConstrainedGrainState>.IndexKeys.Ascending(f => f.Name);
+
+            var options = new CreateIndexOptions
+            {
+                Unique = true
+            };
+
+            var indexModel = new CreateIndexModel<ConstrainedGrainState>(indexBuilder, options);
+
+            await collection.Indexes.CreateOneAsync(indexModel);
         }
 
         private static async Task TestStreams(IClusterClient client)
@@ -204,6 +227,41 @@ namespace Orleans.Providers.MongoDB.Test.Host
             employeeId = await employee.ReturnLevel();
 
             Console.WriteLine(employeeId);
+        }
+        
+        private static async Task TestStateConstraints(IClusterClient client)
+        {
+            var database = client.ServiceProvider.GetRequiredService<IMongoClient>()
+                .GetDatabase("OrleansTestApp");
+
+            var guid = Guid.NewGuid().ToString();
+
+            var grain0 = client.GetGrain<IConstrainedGrain>(0);
+            await grain0.SetName(guid);
+
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", "constrained/0");
+            var update = Builders<BsonDocument>.Update.Set("_etag", Guid.NewGuid().ToString());
+
+            await database.GetCollection<BsonDocument>("GrainsConstrainedGrain").UpdateOneAsync(filter, update);
+
+            try
+            {
+                await grain0.SetName(Guid.NewGuid().ToString());
+            }
+            catch (ProviderStateException ex)
+            {
+                Console.WriteLine($"Exception thrown due to invalid e-tag: {ex.Message}");
+            }
+
+            var grain1 = client.GetGrain<IConstrainedGrain>(1);
+            try
+            {
+                await grain1.SetName(guid);
+            }
+            catch (ProviderStateException ex)
+            {
+                Console.WriteLine($"Exception thrown due to unique constrain violation: {ex.Message}");
+            }
         }
 
         private static void ApplyBsonConfiguration()


### PR DESCRIPTION
Hi!

I have not found better way for detecting which field constraint was violated than "parsing" the exception message.

I've added couple test methods into the test host, as it does not seem there is a unit test approach for the persistence provider.