### PR TITLE
Feat/custom collection configuration

### DIFF
--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGrainStorageOptions.cs
@@ -1,5 +1,8 @@
-﻿using Orleans.Providers.MongoDB.StorageProviders.Serializers;
+﻿using MongoDB.Driver;
+using System;
+using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Runtime;
+using MongoDB.Bson;
 
 namespace Orleans.Providers.MongoDB.Configuration
 {
@@ -23,6 +26,13 @@ namespace Orleans.Providers.MongoDB.Configuration
         /// in the grain reference.
         /// </summary>
         public GrainStorageKeyGenerator KeyGenerator { get; set; } = x => x.ToString();
+
+        /// <summary>
+        /// This delegate is called when the collection is created. It can be used for additional setup
+        /// of collection; for example to add additional indexes.
+        /// </summary>
+        public Action<IMongoCollection<BsonDocument>> CollectionSetupConfigurator { get; set; }
+
 
         internal override void Validate(string name = null)
         {

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -82,7 +82,9 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                     options.CollectionConfigurator,
                     options.CreateShardKeyForCosmos,
                     serializer,
-                    options.KeyGenerator));
+                    options.KeyGenerator,
+                    options.CollectionSetupConfigurator
+                    ));
         }
 
         private Task DoAndLog(string actionName, Func<Task> action)

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorageCollection.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorageCollection.cs
@@ -18,6 +18,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
         private readonly string collectionName;
         private readonly IGrainStateSerializer serializer;
         private readonly GrainStorageKeyGenerator keyGenerator;
+        private readonly Action<IMongoCollection<BsonDocument>> collectionSetupDelegate;
 
         public MongoGrainStorageCollection(
             IMongoClient mongoClient,
@@ -26,12 +27,15 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             Action<MongoCollectionSettings> collectionConfigurator,
             bool createShardKey,
             IGrainStateSerializer serializer,
-            GrainStorageKeyGenerator keyGenerator)
+            GrainStorageKeyGenerator keyGenerator,
+            Action<IMongoCollection<BsonDocument>> collectionSetupDelegate = null
+          )
             : base(mongoClient, databaseName, collectionConfigurator, createShardKey)
         {
             this.collectionName = collectionName;
             this.serializer = serializer;
             this.keyGenerator = keyGenerator;
+            this.collectionSetupDelegate = collectionSetupDelegate;
         }
 
         protected override string CollectionName()
@@ -147,5 +151,10 @@ namespace Orleans.Providers.MongoDB.StorageProviders
                 throw new InconsistentStateException(existingEtag[FieldEtag].AsString, etag, ex);
             }
         }
-    }
+
+        protected override void SetupCollection(IMongoCollection<BsonDocument> collection)
+        {
+            collectionSetupDelegate?.Invoke(collection);
+        }
+  }
 }


### PR DESCRIPTION
This minor feature enhancement introduces an additional Action in the `MongoDBGrainStorageOptions`, which invokes the delegate in the `MongoGrainStorageCollection`'s `SetupCollection` method.

This change facilitates additional configuration of MongoDB collections during the storage setup process. I've provided an exact example of this feature's application in the updated README (an example of how to add extra indexes). Check it out at:  ### Configuring a MongoDB Collection section.

In my personal testing, I found this feature extremely useful as it promotes a hybrid approach. It enables us to leverage the strengths of Orleans while also allowing traditional queries over the grain collections in scenarios where Orleans may not be sufficient.

Cheers,
DInko