### PR TITLE
Upgrading to Orleans 7.2.1 (#127)

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -19,12 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
+++ b/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.2.1" />
   </ItemGroup>
 
 </Project>

--- a/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
+++ b/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Host/Orleans.Providers.MongoDB.Test.Host.csproj
+++ b/Test/Host/Orleans.Providers.MongoDB.Test.Host.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EphemeralMongo6" Version="0.1.3" />
+    <PackageReference Include="EphemeralMongo6" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
+++ b/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
@@ -7,20 +7,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EphemeralMongo6" Version="0.1.3" />
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="EphemeralMongo6" Version="1.1.2" />
+    <PackageReference Include="FakeItEasy" Version="7.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Serialization" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Serialization.Abstractions" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Serialization.TestKit" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
+++ b/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="7.2.1" />
     <PackageReference Include="Microsoft.Orleans.Streaming" Version="7.2.1" />
     <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.2.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.console" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
I have upgraded orleans to 7.2.1.
Some dependencies added to the `Orleans.Providers.MongoDB.UnitTest` project to fix runtime errors.