### PR TITLE
bugfix: using collection name as key for caching collections

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net7.0</TargetFrameworks>
-    <Version>7.6.0</Version>
+    <Version>7.6.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -74,7 +74,7 @@ namespace Orleans.Providers.MongoDB.StorageProviders
         {
             var collectionName = $"{options.CollectionPrefix}{ReturnGrainName<T>(stateName, grainId)}";
 
-            return collections.GetOrAdd(stateName, x =>
+            return collections.GetOrAdd(collectionName, x =>
                 new MongoGrainStorageCollection(
                     mongoClient,
                     options.DatabaseName,


### PR DESCRIPTION
Currently the statename is used as the key for caching collections in the MongoGrainStorage. However the statename is always set to "state" as seen here in the Orleans source code: https://github.com/dotnet/orleans/blob/2bcd83351385c0dd98cd3a60cdcfb17ce890f966/src/Orleans.Runtime/Core/GrainRuntime.cs#L88C42-L88C42

This leads to all grain states using the same mongo collection. It will be the first one that gets created with that key which is likely undeterministic depending on your Orleans application. 

A simple test scenario can highlight this bug. You just need 2 grain types with their own states. Depending on which grain type is activated first, will determine which mongo collection is used. I can provide a test repo if need be.

This fix just uses the collection name as the key in the cache.