### PR TITLE
State serialization: DateTime precision increased

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>8.0.1</Version>
+    <Version>8.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/JsonBsonConverter.cs
@@ -88,11 +88,11 @@ namespace Orleans.Providers.MongoDB.StorageProviders
 
                         if (value is DateTime dateTime)
                         {
-                            return dateTime.ToString("yyyy-MM-ddTHH:mm:ssK");
+                            return dateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK");
                         }
                         else if (value is DateTimeOffset dateTimeOffset)
                         {
-                            return dateTimeOffset.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ssK");
+                            return dateTimeOffset.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFFK");
                         }
                         else
                         {


### PR DESCRIPTION
This PR fixes the following issue: When saving state having DateTime property, anything lower than second is trimmed. After reading from DB (e.g. after re-activation), state is different from the one before deactivation, which causes various problems that typically must be targeted by some workarounds.