### PR TITLE
UpdateIAmAlive for SingleMembership fixed to not create invalid subdocuments without required properties

### DIFF
--- a/Orleans.Providers.MongoDB/Membership/Store/Single/SingleMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Single/SingleMembershipCollection.cs
@@ -92,8 +92,11 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Single
 
         public async Task UpdateIAmAlive(string deploymentId, SiloAddress address, DateTime iAmAliveTime)
         {
-            await Collection.UpdateOneAsync(x => x.DeploymentId == deploymentId,
-                Update
+            var filter = Builders<DeploymentDocument>.Filter.And(
+                Builders<DeploymentDocument>.Filter.Eq(x => x.DeploymentId, deploymentId),
+                Builders<DeploymentDocument>.Filter.Exists($"Members.{BuildKey(address)}", true));
+
+            await Collection.UpdateOneAsync(filter, Update
                     .Set($"Members.{BuildKey(address)}.IAmAliveTime", LogFormatter.PrintDate(iAmAliveTime)));
         }
 


### PR DESCRIPTION
Current implementation of UpdateIAmAlive method for SingleMembership uses update of member qualified by its full path in document, but this update works even if there is no subdocument for given silo. It creates a new document with IAmAlive as its only property (due to some race condition in Orleans membership, when UpdateIAmAlive can be invoked before Insert/Upsert). This invalid document leads to fail for every subsequent read from table, as most of properties in document are BsonRequired.

My fix will ensure that either silo subdocument exists, and change is written, or not, and change is ignored.  