### PR TITLE
Updating mongo library

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,11 +15,11 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>8.0.4</Version>
+    <Version>8.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
+++ b/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
+++ b/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Streaming" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Streaming" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Host/Program.cs
+++ b/Test/Host/Program.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using EphemeralMongo;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,10 +16,6 @@ using Orleans.Hosting;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Providers.MongoDB.Test.GrainInterfaces;
-using System;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Orleans.Providers.MongoDB.Test.Host
 {

--- a/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
+++ b/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
@@ -10,18 +10,18 @@
 
   <ItemGroup>
     <PackageReference Include="EphemeralMongo6" Version="1.1.3" />
-    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="8.0.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator" Version="8.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.6.5" />
-    <PackageReference Include="xunit.runner.console" Version="2.6.5">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UnitTest/Serializers/SerializationTests.cs
+++ b/UnitTest/Serializers/SerializationTests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Orleans.Hosting;
@@ -7,8 +9,6 @@ using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 using Orleans.Providers.MongoDB.UnitTest.Fixtures;
 using Orleans.Runtime;
 using Orleans.Streams;
-using System;
-using System.Threading.Tasks;
 using TestExtensions;
 using Xunit;
 
@@ -70,7 +70,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Serializers
         }
 
         [Fact]
-        public async void BsonSerializerForPubSubStore_Throws()
+        public async Task BsonSerializerForPubSubStore_Throws()
         {
             var host = new HostBuilder()
                 .UseOrleans((ctx, siloBuilder) =>


### PR DESCRIPTION
The new Mongo library is now strongly named it needs to reference the newest library to fix build errors for those projects that want to use the newest library.