### PR TITLE
Updating mongo lib

### DIFF
--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Orleans OrleansProviders MongoDB</PackageTags>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Host/Program.cs
+++ b/Test/Host/Program.cs
@@ -215,9 +215,7 @@ namespace Orleans.Providers.MongoDB.Test.Host
                     new IgnoreExtraElementsConvention(true)
                 },
                 t => true);
-
-            // http://mongodb.github.io/mongo-csharp-driver/2.11/reference/bson/guidserialization/guidrepresentationmode/guidrepresentationmode/
-            BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
+            
             BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
         }
     }


### PR DESCRIPTION
Updating to Mongo 3.0 driver. The BSON representation mode has been removed from the new driver as v3 is now the only option.