### PR TITLE
Validate GrainId Type and Key on reminder creation

### DIFF
--- a/Orleans.Providers.MongoDB/Membership/Store/Multiple/TableVersionCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Multiple/TableVersionCollection.cs
@@ -26,14 +26,14 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Multiple
             return $"{collectionPrefix}OrleansMembershipV3_TableVersion";
         }
 
-        public Task DeleteAsync(string deploymentId)
+        public Task DeleteAsync(IClientSessionHandle session, string deploymentId)
         {
-            return Collection.DeleteOneAsync(x => x.DeploymentId == deploymentId);
+            return Collection.DeleteOneAsync(session, x => x.DeploymentId == deploymentId);
         }
 
-        public async Task<TableVersion> GetTableVersionAsync(string deploymentId)
+        public async Task<TableVersion> GetTableVersionAsync(IClientSessionHandle session, string deploymentId)
         {
-            var deployment = await Collection.Find(x => x.DeploymentId == deploymentId).FirstOrDefaultAsync();
+            var deployment = await Collection.Find(session, x => x.DeploymentId == deploymentId).FirstOrDefaultAsync();
 
             if (deployment == null)
             {
@@ -50,7 +50,7 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Multiple
             try
             {
                 await Collection.ReplaceOneAsync(session,
-                    x => x.DeploymentId == deploymentId && x.VersionEtag == tableVersion.VersionEtag, 
+                    x => x.DeploymentId == deploymentId && x.VersionEtag == tableVersion.VersionEtag,
                     update,
                     UpsertReplace);
 

--- a/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
+++ b/Orleans.Providers.MongoDB/Orleans.Providers.MongoDB.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <Authors>laredoza,sebastianstehle,wassim-k</Authors>
     <Company>Orleans.Providers.MongoDB</Company>
     <Copyright>MIT</Copyright>
-    <Description>A MongoDb implementation of the Orleans Providers. This includes custering (IMembershipTable and IGatewayListProvider), reminders (IReminderTable) and storage providers (IGrainStorage).</Description>
+    <Description>A MongoDb implementation of the Orleans Providers. This includes clustering (IMembershipTable and IGatewayListProvider), reminders (IReminderTable) and storage providers (IGrainStorage).</Description>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="9.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MongoDB.Driver" Version="3.2.1" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Orleans.Providers.MongoDB/Reminders/Store/MongoReminderCollection.cs
+++ b/Orleans.Providers.MongoDB/Reminders/Store/MongoReminderCollection.cs
@@ -200,6 +200,14 @@ namespace Orleans.Providers.MongoDB.Reminders.Store
 
         private static string ReturnId(string serviceId, GrainId grainId, string reminderName)
         {
+            var grainType = grainId.Type.ToString();
+            var grainKey = grainId.Key.ToString();
+
+            if (grainType is null || grainKey is null)
+            {
+                throw new ArgumentNullException(nameof(grainId));
+            }
+
             return $"{serviceId}_{grainId}_{reminderName}";
         }
     }

--- a/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
+++ b/Orleans.Providers.MongoDB/StorageProviders/MongoGrainStorage.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
@@ -12,14 +11,13 @@ using Orleans.Storage;
 
 namespace Orleans.Providers.MongoDB.StorageProviders
 {
-    public class MongoGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
+    public class MongoGrainStorage : IGrainStorage
     {
         private readonly ConcurrentDictionary<string, MongoGrainStorageCollection> collections = new ConcurrentDictionary<string, MongoGrainStorageCollection>();
         private readonly MongoDBGrainStorageOptions options;
         private readonly IMongoClient mongoClient;
         private readonly ILogger<MongoGrainStorage> logger;
         private readonly IGrainStateSerializer serializer;
-        private IMongoDatabase database;
 
         public MongoGrainStorage(
             IMongoClientFactory mongoClientFactory,
@@ -30,21 +28,6 @@ namespace Orleans.Providers.MongoDB.StorageProviders
             this.logger = logger;
             this.options = options;
             this.serializer = options.GrainStateSerializer;
-        }
-
-        public void Participate(ISiloLifecycle lifecycle)
-        {
-            lifecycle.Subscribe<MongoGrainStorage>(ServiceLifecycleStage.ApplicationServices, Init);
-        }
-
-        private Task Init(CancellationToken ct)
-        {
-            return DoAndLog(nameof(Init), () =>
-            {
-                database = mongoClient.GetDatabase(options.DatabaseName);
-
-                return Task.CompletedTask;
-            });
         }
 
         public Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)

--- a/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
+++ b/Test/GrainInterfaces/Orleans.Providers.MongoDB.Test.GrainInterfaces.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="9.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
+++ b/Test/Grains/Orleans.Providers.MongoDB.Test.Grains.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="9.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Streaming" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Host/Orleans.Providers.MongoDB.Test.Host.csproj
+++ b/Test/Host/Orleans.Providers.MongoDB.Test.Host.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
-    <PackageReference Include="MongoSandbox8" Version="1.0.1" />
+    <PackageReference Include="MongoSandbox.Core" Version="2.0.0" />
+    <PackageReference Include="MongoSandbox8.runtime.linux-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="MongoSandbox8.runtime.osx-arm64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="MongoSandbox8.runtime.win-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/Host/Program.cs
+++ b/Test/Host/Program.cs
@@ -25,7 +25,7 @@ namespace Orleans.Providers.MongoDB.Test.Host
         {
             var createShardKey = false;
 
-            using var mongoRunner = MongoRunner.Run(new MongoRunnerOptions { KillMongoProcessesWhenCurrentProcessExits = true });
+            using var mongoRunner = MongoRunner.Run();
 
             Console.WriteLine("MongoDB ConnectionString: {0}", mongoRunner.ConnectionString);
 

--- a/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
+++ b/UnitTest/Orleans.Providers.MongoDB.UnitTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -9,8 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MongoSandbox8" Version="1.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MongoSandbox.Core" Version="2.0.0" />
+    <PackageReference Include="MongoSandbox8.runtime.linux-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="MongoSandbox8.runtime.osx-arm64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
+    <PackageReference Include="MongoSandbox8.runtime.win-x64" Version="2.0.0" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Related to #145

This change also downgrades Orleans and MongoDB.Driver to the lowest non-breaking version to avoid forcing library users from upgrading their dependencies.