### PR TITLE
Mongo Query Plan Test quality assessment

### DIFF
--- a/UnitTest/Fixtures/MongoDatabaseFixture.cs
+++ b/UnitTest/Fixtures/MongoDatabaseFixture.cs
@@ -9,8 +9,14 @@ namespace Orleans.Providers.MongoDB.UnitTest.Fixtures
     {
         private bool disposedValue;
 
-        private static readonly Lazy<IMongoRunner> _databaseRunner = new(() => MongoRunner.Run());
-        private static readonly Lazy<IMongoRunner> _replicaSetRunner = new(() => MongoRunner.Run(new MongoRunnerOptions { UseSingleNodeReplicaSet = true }));
+        private static readonly Lazy<IMongoRunner> _databaseRunner = new(
+            () => MongoRunner.Run(),
+            LazyThreadSafetyMode.ExecutionAndPublication
+        );
+        private static readonly Lazy<IMongoRunner> _replicaSetRunner = new(
+            () => MongoRunner.Run(new MongoRunnerOptions { UseSingleNodeReplicaSet = true }),
+            LazyThreadSafetyMode.ExecutionAndPublication
+        );
 
         public static string DatabaseConnectionString => _databaseRunner.Value.ConnectionString;
 

--- a/UnitTest/Fixtures/MongoDatabaseFixture.cs
+++ b/UnitTest/Fixtures/MongoDatabaseFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using MongoDB.Driver;
 using MongoSandbox;
 using Orleans.Providers.MongoDB.Utils;
@@ -21,10 +22,6 @@ namespace Orleans.Providers.MongoDB.UnitTest.Fixtures
         public static string DatabaseConnectionString => _databaseRunner.Value.ConnectionString;
 
         public static string ReplicaSetConnectionString => _replicaSetRunner.Value.ConnectionString;
-
-        public static IMongoClientFactory DatabaseFactory => new DefaultMongoClientFactory(new MongoClient(DatabaseConnectionString));
-
-        public static IMongoClientFactory ReplicaSetFactory => new DefaultMongoClientFactory(new MongoClient(ReplicaSetConnectionString));
 
         protected virtual void Dispose(bool disposing)
         {

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
@@ -9,6 +9,7 @@ using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Providers.MongoDB.UnitTest.Membership
 {
@@ -16,11 +17,13 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_Multiple : MembershipTableTestsBase
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private MongoClientJig mongoClientFixture;
 
-        public MongoMembershipTableTests_Multiple(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+        public MongoMembershipTableTests_Multiple(ConnectionStringFixture fixture, TestEnvironmentFixture environment, ITestOutputHelper testOutputHelper)
             : base(fixture, environment, new LoggerFilterOptions())
         {
+            this.testOutputHelper = testOutputHelper;
         }
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
@@ -73,63 +76,63 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
     }
 }

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
@@ -16,6 +16,8 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_Multiple : MembershipTableTestsBase
     {
+        private MongoClientJig mongoClientFixture;
+
         public MongoMembershipTableTests_Multiple(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
             : base(fixture, environment, new LoggerFilterOptions())
         {
@@ -23,6 +25,10 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
+            // the virtual method is called from the base constructor, which means there wasn't a chance to
+            // initialize the field via the typical constructor
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBMembershipTableOptions
             {
                 CollectionPrefix = "Test_",
@@ -31,7 +37,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoMembershipTable(
-                MongoDatabaseFixture.ReplicaSetFactory,
+                mongoClientFixture.CreateReplicaSetFactory(),
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
                 options);
@@ -39,6 +45,10 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
+            // the virtual method is called from the base constructor, which means there wasn't a chance to
+            // initialize the field via the typical constructor
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBGatewayListProviderOptions
             {
                 CollectionPrefix = "Test_",
@@ -47,7 +57,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoGatewayListProvider(
-                MongoDatabaseFixture.ReplicaSetFactory,
+                mongoClientFixture.CreateReplicaSetFactory(),
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
                 _gatewayOptions,
@@ -63,54 +73,63 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
     }
 }

--- a/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
@@ -10,6 +10,7 @@ using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Providers.MongoDB.UnitTest.Membership
 {
@@ -17,11 +18,13 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_MultipleDeprecated : MembershipTableTestsBase
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private MongoClientJig mongoClientFixture;
 
-        public MongoMembershipTableTests_MultipleDeprecated(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+        public MongoMembershipTableTests_MultipleDeprecated(ConnectionStringFixture fixture, TestEnvironmentFixture environment, ITestOutputHelper testOutputHelper)
             : base(fixture, environment, new LoggerFilterOptions())
         {
+            this.testOutputHelper = testOutputHelper;
         }
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
@@ -70,56 +73,56 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(false);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(false);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(false);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(false);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(false);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
     }
 }

--- a/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
@@ -17,6 +17,8 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_MultipleDeprecated : MembershipTableTestsBase
     {
+        private MongoClientJig mongoClientFixture;
+
         public MongoMembershipTableTests_MultipleDeprecated(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
             : base(fixture, environment, new LoggerFilterOptions())
         {
@@ -24,6 +26,10 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
+            // the virtual method is called from the base constructor, which means there wasn't a chance to
+            // initialize the field via the typical constructor
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBMembershipTableOptions
             {
                 CollectionPrefix = "Test_",
@@ -32,7 +38,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoMembershipTable(
-                MongoDatabaseFixture.DatabaseFactory,
+                mongoClientFixture.CreateDatabaseFactory(),
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
                 options);
@@ -48,7 +54,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoGatewayListProvider(
-                MongoDatabaseFixture.DatabaseFactory,
+                mongoClientFixture.CreateDatabaseFactory(),
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
                 _gatewayOptions,
@@ -64,48 +70,56 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(false);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(false);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(false);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(false);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(false);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
     }
 }

--- a/UnitTest/Membership/MongoMembershipTableTests_Single.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Single.cs
@@ -10,6 +10,7 @@ using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Providers.MongoDB.UnitTest.Membership
 {
@@ -17,11 +18,13 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_Single : MembershipTableTestsBase
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private MongoClientJig mongoClientFixture;
 
-        public MongoMembershipTableTests_Single(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+        public MongoMembershipTableTests_Single(ConnectionStringFixture fixture, TestEnvironmentFixture environment, ITestOutputHelper testOutputHelper)
             : base(fixture, environment, new LoggerFilterOptions())
         {
+            this.testOutputHelper = testOutputHelper;
         }
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
@@ -74,63 +77,63 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive(true);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
     }
 }

--- a/UnitTest/Membership/MongoMembershipTableTests_Single.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Single.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Messaging;
@@ -16,6 +17,8 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
     [TestCategory("Mongo")]
     public class MongoMembershipTableTests_Single : MembershipTableTestsBase
     {
+        private MongoClientJig mongoClientFixture;
+
         public MongoMembershipTableTests_Single(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
             : base(fixture, environment, new LoggerFilterOptions())
         {
@@ -23,6 +26,10 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
 
         protected override IMembershipTable CreateMembershipTable(ILogger logger)
         {
+            // the virtual method is called from the base constructor, which means there wasn't a chance to
+            // initialize the field via the typical constructor
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBMembershipTableOptions
             {
                 CollectionPrefix = "Test_",
@@ -31,7 +38,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoMembershipTable(
-                MongoDatabaseFixture.DatabaseFactory,
+                mongoClientFixture.CreateReplicaSetFactory(),
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
                 options);
@@ -39,6 +46,10 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
 
         protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
         {
+            // the virtual method is called from the base constructor, which means there wasn't a chance to
+            // initialize the field via the typical constructor
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBGatewayListProviderOptions
             {
                 CollectionPrefix = "Test_",
@@ -47,7 +58,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
             });
 
             return new MongoGatewayListProvider(
-                MongoDatabaseFixture.DatabaseFactory,
+                mongoClientFixture.CreateReplicaSetFactory(),
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
                 _gatewayOptions,
@@ -63,54 +74,63 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
         public async Task Test_CleanupDefunctSiloEntries()
         {
             await MembershipTable_CleanupDefunctSiloEntries();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_GetGateways()
         {
             await MembershipTable_GetGateways();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_EmptyTable()
         {
             await MembershipTable_ReadAll_EmptyTable();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_InsertRow()
         {
             await MembershipTable_InsertRow(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadRow_Insert_Read()
         {
             await MembershipTable_ReadRow_Insert_Read(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_ReadAll_Insert_ReadAll()
         {
             await MembershipTable_ReadAll_Insert_ReadAll(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRow()
         {
             await MembershipTable_UpdateRow(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateRowInParallel()
         {
             await MembershipTable_UpdateRowInParallel(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact, TestCategory("Functional")]
         public async Task Test_UpdateIAmAlive()
         {
             await MembershipTable_UpdateIAmAlive(true);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
     }
 }

--- a/UnitTest/MongoClientJig.cs
+++ b/UnitTest/MongoClientJig.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using Orleans.Providers.MongoDB.UnitTest.Fixtures;
+using Orleans.Providers.MongoDB.Utils;
+
+namespace Orleans.Providers.MongoDB.UnitTest;
+
+public class MongoClientJig
+{
+    public IMongoClientFactory CreateDatabaseFactory()
+    {
+        return new DefaultMongoClientFactory(new MongoClient(MongoDatabaseFixture.DatabaseConnectionString));
+    }
+
+    public IMongoClientFactory CreateReplicaSetFactory()
+    {
+        return new DefaultMongoClientFactory(new MongoClient(MongoDatabaseFixture.ReplicaSetConnectionString));
+    }
+
+    public Task AssertQualityChecksAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/UnitTest/MongoClientJig.cs
+++ b/UnitTest/MongoClientJig.cs
@@ -1,25 +1,146 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Events;
 using Orleans.Providers.MongoDB.UnitTest.Fixtures;
 using Orleans.Providers.MongoDB.Utils;
 
 namespace Orleans.Providers.MongoDB.UnitTest;
 
-public class MongoClientJig
+/// <summary>
+/// Provides utility methods and factories for interacting with MongoDB clients during unit tests.
+/// </summary>
+internal class MongoClientJig
 {
+    private readonly MongoClientSettings databaseClientSettings;
+    private readonly MongoClientSettings replicaSetClientSettings;
+    
+    private readonly List<BsonDocument> databaseTrackedCommands;
+    private readonly List<BsonDocument> replicaSetTrackedCommands;
+    
+    private readonly object locker = new();
+
+    public MongoClientJig()
+    {
+        (databaseClientSettings, databaseTrackedCommands) = CreateClientSettings(locker, MongoDatabaseFixture.DatabaseConnectionString);
+        (replicaSetClientSettings, replicaSetTrackedCommands) = CreateClientSettings(locker, MongoDatabaseFixture.ReplicaSetConnectionString);
+    }
+
+    private static (MongoClientSettings, List<BsonDocument>) CreateClientSettings(object locker, string connectionString)
+    {
+        var settings = MongoClientSettings.FromConnectionString(connectionString);
+        var commands = new List<BsonDocument>();
+
+        settings.ClusterConfigurator = cb => cb.Subscribe<CommandStartedEvent>(e =>
+        {
+            lock (locker) commands.Add(e.Command.DeepClone().AsBsonDocument);
+        });
+
+        return (settings, commands);
+    }
+    
+    
     public IMongoClientFactory CreateDatabaseFactory()
     {
-        return new DefaultMongoClientFactory(new MongoClient(MongoDatabaseFixture.DatabaseConnectionString));
+        return new DefaultMongoClientFactory(new MongoClient(databaseClientSettings));
     }
 
     public IMongoClientFactory CreateReplicaSetFactory()
     {
-        return new DefaultMongoClientFactory(new MongoClient(MongoDatabaseFixture.ReplicaSetConnectionString));
+        return new DefaultMongoClientFactory(new MongoClient(replicaSetClientSettings));
     }
 
     public Task AssertQualityChecksAsync()
     {
-        return Task.CompletedTask;
+        List<InspectQueryPlan> inspections = [
+            CheckNoCollectionScans,
+        ];
+        
+        return Task.WhenAll(
+            AssertQualityVerificationsAsync(MongoDatabaseFixture.DatabaseConnectionString, databaseTrackedCommands, inspections),
+            AssertQualityVerificationsAsync(MongoDatabaseFixture.ReplicaSetConnectionString, replicaSetTrackedCommands, inspections)
+        );
+    }
+
+    private async Task AssertQualityVerificationsAsync(string databaseConnectionString, List<BsonDocument> trackedCommands, List<InspectQueryPlan> inspections)
+    {
+        if (trackedCommands.Count == 0)
+        {
+            return;
+        }
+        
+        using var client = new MongoClient(databaseConnectionString);
+        var queriesToInspect = FetchUniqueQueries(trackedCommands);
+
+        foreach (var query in queriesToInspect)
+        {
+            var database = client.GetDatabase(query["$db"].AsString);
+            query.Remove("$db");
+            
+            var explainDocument = await database.RunCommandAsync<BsonDocument>(new BsonDocument
+            {
+                { "explain", query }
+            });
+
+            foreach (var inspection in inspections)
+                inspection(explainDocument, query);
+        }
+    }
+
+    private static IEnumerable<BsonDocument> FetchUniqueQueries(List<BsonDocument> commands)
+    {
+        return commands
+            // find commands of interest as query fingerprints
+            .Select(query=> (MongoQueryPlanFingerprint.CreateFingerprint(query), query))
+            .Where(x=>!string.IsNullOrEmpty(x.Item1))
+            .GroupBy(i => i.Item1, i => i.query)
+            // now randomly select 5 queries to test against
+            .SelectMany(g => g.OrderBy(_ => Guid.NewGuid()).Take(5))
+            .Select(x=>new BsonDocument(x));
+    }
+
+    public delegate void InspectQueryPlan(BsonDocument explainedResult, BsonDocument originalQuery);
+
+    public class InspectionException(string message, BsonDocument explainedResult)
+        : Exception($"{message}; plan: {explainedResult}");
+
+    private static void CheckNoCollectionScans(BsonDocument explainedResult, BsonDocument originalQuery)
+    {
+        InspectAllStages(
+            GetWinningPlan(explainedResult),
+            plan =>
+            {
+                if (plan.TryGetElement("stage", out var value) && value.Value.AsString == "COLLSCAN")
+                    throw new InspectionException("Collection was scanned", explainedResult);
+            }
+        );
+    }
+    
+    private static BsonDocument GetWinningPlan(BsonDocument explainedPlan) => explainedPlan["queryPlanner"]["winningPlan"].AsBsonDocument;
+
+    private static void InspectAllStages(BsonDocument rootPlan, Action<BsonDocument> action)
+    {
+        var queue = new Queue<BsonDocument>([rootPlan]);
+
+        while (queue.TryDequeue(out var plan))
+        {
+            action(plan);
+
+            if (plan.TryGetElement("inputStage", out var inputStage))
+            {
+                queue.Enqueue(inputStage.Value.AsBsonDocument);
+            }
+
+            if (plan.TryGetElement("inputStages", out var inputStages))
+            {
+                foreach (var inner in inputStages.Value.AsBsonArray)
+                {
+                    queue.Enqueue(inner.AsBsonDocument);
+                }
+            }
+        }
     }
 }

--- a/UnitTest/MongoQueryPlanFingerprint.cs
+++ b/UnitTest/MongoQueryPlanFingerprint.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using MongoDB.Bson;
+
+namespace Orleans.Providers.MongoDB.UnitTest;
+
+/// <summary>
+/// Provides functionality to generate a unique fingerprint representation of a MongoDB query plan.
+/// This fingerprint can be used for identifying and grouping similar queries within a database workload.
+/// </summary>
+internal static class MongoQueryPlanFingerprint
+{
+    private static readonly (string CommandType, Func<BsonDocument, IEnumerable<string>> Generator)[] Walkers = [
+        ("find", document => WalkFilter(document["filter"].AsBsonDocument)),
+        ("delete", document => WalkFilter(document["deletes"].AsBsonArray)),
+        ("findAndModify", document => WalkFilter(document["query"].AsBsonDocument)),
+        (
+            "update",
+            document => WalkNested(
+                document["updates"].AsBsonArray, 
+                innerDoc => WalkFilter(innerDoc["q"].AsBsonDocument)
+            )
+        ),
+    ];
+
+    /// <summary>
+    /// Creates a unique fingerprint representation of a MongoDB query.
+    /// </summary>
+    /// <param name="query">The MongoDB query as a <see cref="BsonDocument"/> to generate a fingerprint for.</param>
+    /// <returns>
+    /// A string representing the fingerprint of the MongoDB query, or null if no matching fingerprint is generated.
+    /// </returns>
+    public static string CreateFingerprint(BsonDocument query)
+    {
+        return Walkers.Where(walker => query.Contains(walker.CommandType))
+            .Select(walker => $"{walker.CommandType}={query[walker.CommandType].AsString}:{walker.Generator(query)}")
+            .FirstOrDefault();
+    }
+
+    private static IEnumerable<string> WalkFilter(BsonValue seedDocument)
+    {
+        // we use a stack so we have a finite recursion cycle
+        var sb = new StringBuilder();
+        var stack = new Stack<(string[] Path, BsonValue Container)>([([], seedDocument)]);
+
+        while (stack.TryPop(out var current))
+        {
+            switch (current.Container)
+            {
+                case BsonDocument doc:
+                    foreach (var element in doc.Elements)
+                    {
+                        // step into and unpack the sub-document
+                        stack.Push((current.Path.Concat([element.Name]).ToArray(), element.Value));
+                    }
+
+                    break;
+                case BsonArray array:
+                    int counter = 0;
+                    foreach (var element in array)
+                    {
+                        // step into and unpack the array contents
+                        stack.Push((current.Path.Concat([counter.ToString()]).ToArray(), element));
+                        counter++;
+                    }
+
+                    break;
+                default:
+                    if (current.Path.Length > 0)
+                    {
+                        sb.AppendJoin('.', current.Path);
+                        sb.Append('|');
+                    }
+
+                    break;
+            }
+        }
+        
+        return [sb.ToString()];
+    }
+
+    private static IEnumerable<string> WalkNested(BsonArray container, Func<BsonDocument, IEnumerable<string>> nested)
+    {
+        return container.SelectMany(item => nested(item.AsBsonDocument));
+    }
+}

--- a/UnitTest/MongoQueryPlanFingerprint.cs
+++ b/UnitTest/MongoQueryPlanFingerprint.cs
@@ -26,16 +26,28 @@ internal static class MongoQueryPlanFingerprint
     ];
 
     /// <summary>
+    /// Retrieves the type of the MongoDB command represented in the given document.
+    /// </summary>
+    /// <param name="commandDocument">A <see cref="BsonDocument"/> representing the MongoDB command for which the type will be determined.</param>
+    /// <returns>
+    /// A string representing the command type if it is present in the document; otherwise, null.
+    /// </returns>
+    public static string GetCommandType(BsonDocument commandDocument)
+    {
+        return Walkers.FirstOrDefault(walker => commandDocument.Contains(walker.CommandType)).CommandType;
+    }
+
+    /// <summary>
     /// Creates a unique fingerprint representation of a MongoDB query.
     /// </summary>
-    /// <param name="query">The MongoDB query as a <see cref="BsonDocument"/> to generate a fingerprint for.</param>
+    /// <param name="commandDocument">The MongoDB query as a <see cref="BsonDocument"/> to generate a fingerprint for.</param>
     /// <returns>
     /// A string representing the fingerprint of the MongoDB query, or null if no matching fingerprint is generated.
     /// </returns>
-    public static string CreateFingerprint(BsonDocument query)
+    public static string CreateFingerprint(BsonDocument commandDocument)
     {
-        return Walkers.Where(walker => query.Contains(walker.CommandType))
-            .Select(walker => $"{walker.CommandType}={query[walker.CommandType].AsString}:{walker.Generator(query)}")
+        return Walkers.Where(walker => commandDocument.Contains(walker.CommandType))
+            .Select(walker => $"{walker.CommandType}={commandDocument[walker.CommandType].AsString}:{walker.Generator(commandDocument)}")
             .FirstOrDefault();
     }
 

--- a/UnitTest/Reminders/MongoReminderTableTests.cs
+++ b/UnitTest/Reminders/MongoReminderTableTests.cs
@@ -15,6 +15,8 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
     [TestCategory("Mongo")]
     public class MongoReminderTableTests : ReminderTableTestsBase
     {
+        private MongoClientJig mongoClientFixture;
+
         public MongoReminderTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture)
             : base(fixture, clusterFixture, new LoggerFilterOptions())
         {
@@ -22,6 +24,8 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
 
         protected override IReminderTable CreateRemindersTable()
         {
+            mongoClientFixture ??= new MongoClientJig();
+            
             var options = Options.Create(new MongoDBRemindersOptions
             {
                 CollectionPrefix = "Test_",
@@ -29,7 +33,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
             });
 
             return new MongoReminderTable(
-                MongoDatabaseFixture.DatabaseFactory,
+                mongoClientFixture.CreateDatabaseFactory(),
                 loggerFactory.CreateLogger<MongoReminderTable>(),
                 options,
                 clusterOptions);
@@ -44,18 +48,21 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
         public async Task Test_RemindersRange()
         {
             await RemindersRange(50);
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact]
         public async Task Test_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
 
         [Fact]
         public async Task Test_ReminderSimple()
         {
             await ReminderSimple();
+            await mongoClientFixture.AssertQualityChecksAsync();
         }
     }
 }

--- a/UnitTest/Reminders/MongoReminderTableTests.cs
+++ b/UnitTest/Reminders/MongoReminderTableTests.cs
@@ -8,6 +8,7 @@ using TestExtensions;
 using UnitTests;
 using UnitTests.RemindersTest;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Orleans.Providers.MongoDB.UnitTest.Reminders
 {
@@ -15,11 +16,13 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
     [TestCategory("Mongo")]
     public class MongoReminderTableTests : ReminderTableTestsBase
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private MongoClientJig mongoClientFixture;
 
-        public MongoReminderTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture)
+        public MongoReminderTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture clusterFixture, ITestOutputHelper testOutputHelper)
             : base(fixture, clusterFixture, new LoggerFilterOptions())
         {
+            this.testOutputHelper = testOutputHelper;
         }
 
         protected override IReminderTable CreateRemindersTable()
@@ -48,21 +51,21 @@ namespace Orleans.Providers.MongoDB.UnitTest.Reminders
         public async Task Test_RemindersRange()
         {
             await RemindersRange(50);
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact]
         public async Task Test_RemindersParallelUpsert()
         {
             await RemindersParallelUpsert();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
 
         [Fact]
         public async Task Test_ReminderSimple()
         {
             await ReminderSimple();
-            await mongoClientFixture.AssertQualityChecksAsync();
+            await mongoClientFixture.AssertQualityChecksAsync(testOutputHelper);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces quality control assessment on mongo commands/queries.

The primary motivation is to ensure that all contributions being proposed meets the minimum requirements and attributes of a first-class library.

In addition, the test output will also print various statistics for consideration by developers to measure quantitively their future improvements.

### Test Infrastructure Improvements

* Replaced static factories (`MongoDatabaseFixture.DatabaseFactory` and `MongoDatabaseFixture.ReplicaSetFactory`) with instance factories from the new `MongoClientJig` class in all membership table test classes, improving test isolation and flexibility.
* Added `MongoClientJig.AssertQualityChecksAsync` calls after each test to verify MongoDB client and database quality, using `ITestOutputHelper` for logging.

### Constructor and Initialization Changes

* Updated test class constructors to take `ITestOutputHelper` as a parameter and initialize `MongoClientJig`, ensuring that the jig is able to output statistics to the test output.
* Added comments and logic to handle initialization of `mongoClientFixture` in overridden methods, addressing timing issues with base constructor calls.

### Thread-Safety Enhancement

* Updated `MongoDatabaseFixture` to use `LazyThreadSafetyMode.ExecutionAndPublication` for thread-safe lazy initialization of MongoDB runners.

---

## Example Output

```
Query statistics: { count = 50, returnedToKeysExamimedRatio = 0, returnedToDocsExamimedRatio = 0 }

Sampled query: { "update" : "Test_OrleansReminderV2", "ordered" : true, "lsid" : { "id" : { "$binary" : { "base64" : "v4lcSoq6RECRsmU9c8I2fg==", "subType" : "04" } } }, "updates" : [{ "q" : { "_id" : "a530464f-e200-4b68-9918-8c4525de5881/foo_sys.grain.v1.0600000000003039/44393D44194558A40B545A0FB42414B9+foo/bar\\#baz?_33" }, "u" : { "_id" : "a530464f-e200-4b68-9918-8c4525de5881/foo_sys.grain.v1.0600000000003039/44393D44194558A40B545A0FB42414B9+foo/bar\\#baz?_33", "ServiceId" : "a530464f-e200-4b68-9918-8c4525de5881/foo", "GrainId" : "sys.grain.v1.0600000000003039/44393D44194558A40B545A0FB42414B9+foo/bar\\#baz?", "ReminderName" : "33", "Etag" : "e78816d0-e726-4454-af31-44a188886f0a", "Period" : "00:01:00", "GrainHash" : 1347860281, "IsDeleted" : false, "StartAt" : { "$date" : "2025-12-09T05:40:21Z" } }, "upsert" : true }] }

----


Query statistics: { count = 52, returnedToKeysExamimedRatio = 1, returnedToDocsExamimedRatio = 1 }

Sampled query: { "find" : "Test_OrleansReminderV2", "filter" : { "$and" : [{ "IsDeleted" : false }, { "ServiceId" : "a530464f-e200-4b68-9918-8c4525de5881/foo" }, { "$or" : [{ "GrainHash" : { "$gt" : 4171130056 } }, { "GrainHash" : { "$lte" : 2982566653 } }] }] }, "lsid" : { "id" : { "$binary" : { "base64" : "Y8dIkVzyThGYCym+y54rfQ==", "subType" : "04" } } } }

----


COMMAND TOTAL COUNTS:
update: 50
find: 52

COMMAND TOTAL COUNTS: 102
```