### PR TITLE
Chore: Tidy reminders

### DIFF
--- a/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
+++ b/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
@@ -101,14 +101,7 @@ namespace Orleans.Providers.MongoDB.Reminders
         {
             return DoAndLog(nameof(ReadRows), () =>
             {
-                if (begin < end)
-                {
-                    return collection.ReadRowsInRange(begin, end);
-                }
-                else
-                {
-                    return collection.ReadRowsOutRange(begin, end);
-                }
+                return collection.ReadRows(begin, end);
             });
         }
 

--- a/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
+++ b/Orleans.Providers.MongoDB/Reminders/MongoReminderTable.cs
@@ -30,7 +30,7 @@ namespace Orleans.Providers.MongoDB.Reminders
             IOptions<MongoDBRemindersOptions> options,
             IOptions<ClusterOptions> clusterOptions)
         {
-            this.mongoClient = mongoClientFactory.Create(options.Value, "Membership");
+            this.mongoClient = mongoClientFactory.Create(options.Value, "Reminder");
             this.logger = logger;
             this.options = options.Value;
             this.serviceId = clusterOptions.Value.ServiceId ?? string.Empty;

--- a/Orleans.Providers.MongoDB/Reminders/Store/MongoReminderCollection.cs
+++ b/Orleans.Providers.MongoDB/Reminders/Store/MongoReminderCollection.cs
@@ -104,18 +104,6 @@ namespace Orleans.Providers.MongoDB.Reminders.Store
             return reminder?.ToEntry();
         }
 
-        public virtual async Task<ReminderTableData> ReadReminderRowsAsync(GrainId grainId)
-        {
-            var reminders =
-                await Collection.Find(x =>
-                        x.IsDeleted == false &&
-                        x.ServiceId == serviceId &&
-                        x.GrainId == grainId.ToString())
-                    .ToListAsync();
-
-            return new ReminderTableData(reminders.Select(x => x.ToEntry()));
-        }
-
         public virtual async Task<ReminderTableData> ReadRowsOutRange(uint beginHash, uint endHash)
         {
             var reminders =


### PR DESCRIPTION
This pull request updates the MongoDB-based reminders provider in Orleans to fix hash range queries and clarify client naming.

> [!NOTE]
> It would be easier to review this PR bundle commit by commit. It just happens that two unrelated changes were next to each other.

**Hash range query logic alignment:**

* In `MongoReminderTable.cs`, the call to `ReadRowsInRange` and `ReadRowsOutRange` has been removed
* In `MongoReminderCollection.cs`, the implementation of `ReadRowsInRange` and `ReadRowsOutRange` has consolidated to repeat the pre-existing pattern established by other Orleans providers.

**Unused code:**

* In `MongoReminderCollection.cs`, the `ReadReminderRowsAsync` method was never called. This method was deleted.

**Client naming improvement:**

* The MongoDB client creation in `MongoReminderTable.cs` now uses the name `"Reminder"` instead of `"Membership"` for clarity and correctness.