### PR TITLE
Use Mongo TTL Indexes on Multi Document Membership

### DIFF
--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGatewayListProviderOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGatewayListProviderOptions.cs
@@ -9,14 +9,6 @@ namespace Orleans.Providers.MongoDB.Configuration
     {
         public MongoDBMembershipStrategy Strategy { get; set; }
 
-        /// <summary>
-        /// Specifies whether a TTL (Time-to-Live) index should be utilized in MongoDB for managing gateway entries.
-        /// When enabled, the TTL index automatically removes expired gateway records from the collection
-        /// based on the configured expiration settings in
-        /// <see cref="Orleans.Configuration.ClusterMembershipOptions.DefunctSiloExpiration"/>
-        /// </summary>
-        public bool UseMongoTtlIndex { get; set; }
-
         public MongoDBGatewayListProviderOptions()
         {
         }

--- a/Orleans.Providers.MongoDB/Configuration/MongoDBGatewayListProviderOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBGatewayListProviderOptions.cs
@@ -9,6 +9,14 @@ namespace Orleans.Providers.MongoDB.Configuration
     {
         public MongoDBMembershipStrategy Strategy { get; set; }
 
+        /// <summary>
+        /// Specifies whether a TTL (Time-to-Live) index should be utilized in MongoDB for managing gateway entries.
+        /// When enabled, the TTL index automatically removes expired gateway records from the collection
+        /// based on the configured expiration settings in
+        /// <see cref="Orleans.Configuration.ClusterMembershipOptions.DefunctSiloExpiration"/>
+        /// </summary>
+        public bool UseMongoTtlIndex { get; set; }
+
         public MongoDBGatewayListProviderOptions()
         {
         }

--- a/Orleans.Providers.MongoDB/Configuration/MongoDBMembershipTableOptions.cs
+++ b/Orleans.Providers.MongoDB/Configuration/MongoDBMembershipTableOptions.cs
@@ -9,6 +9,17 @@ namespace Orleans.Providers.MongoDB.Configuration
     {
         public MongoDBMembershipStrategy Strategy { get; set; }
 
+        /// <summary>
+        /// Determines whether a TTL index is created and used in the MongoDB collection for cluster membership entries.
+        /// When enabled, entries in the collection are subject to automatic expiration based on a system-defined time-to-live (TTL)
+        /// as configured in <see cref="Orleans.Configuration.ClusterMembershipOptions.DefunctSiloExpiration"/>.
+        /// </summary>
+        /// <remarks>
+        /// Enabling this property can help automatically clean up expired cluster membership data in MongoDB.
+        /// This behavior depends on the TTL feature of MongoDB and the proper initialization of the TTL index in the collection.
+        /// </remarks>
+        public bool UseMongoTtlIndex { get; set; }
+
         public MongoDBMembershipTableOptions()
         {
         }

--- a/Orleans.Providers.MongoDB/Membership/MongoGatewayListProvider.cs
+++ b/Orleans.Providers.MongoDB/Membership/MongoGatewayListProvider.cs
@@ -18,6 +18,7 @@ namespace Orleans.Providers.MongoDB.Membership
     {
         private readonly IMongoClient mongoClient;
         private readonly ILogger<MongoGatewayListProvider> logger;
+        private readonly ClusterMembershipOptions clusterMembershipOptions;
         private readonly MongoDBGatewayListProviderOptions options;
         private readonly string clusterId;
         private IMongoMembershipCollection gatewaysCollection;
@@ -32,11 +33,13 @@ namespace Orleans.Providers.MongoDB.Membership
             IMongoClientFactory mongoClientFactory,
             ILogger<MongoGatewayListProvider> logger,
             IOptions<ClusterOptions> clusterOptions,
+            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
             IOptions<GatewayOptions> gatewayOptions,
             IOptions<MongoDBGatewayListProviderOptions> options)
         {
             this.mongoClient = mongoClientFactory.Create(options.Value, "Membership");
             this.logger = logger;
+            this.clusterMembershipOptions = clusterMembershipOptions.Value;
             this.options = options.Value;
             this.clusterId = clusterOptions.Value.ClusterId;
             this.MaxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
@@ -47,7 +50,7 @@ namespace Orleans.Providers.MongoDB.Membership
         {
             CreateCollection();
 
-            return Task.CompletedTask;
+            return gatewaysCollection.InitializeTtl(clusterId, clusterMembershipOptions.GetMongoTtlTimeSpan(options.UseMongoTtlIndex));
         }
 
         private void CreateCollection()

--- a/Orleans.Providers.MongoDB/Membership/MongoGatewayListProvider.cs
+++ b/Orleans.Providers.MongoDB/Membership/MongoGatewayListProvider.cs
@@ -49,8 +49,7 @@ namespace Orleans.Providers.MongoDB.Membership
         public Task InitializeGatewayListProvider()
         {
             CreateCollection();
-
-            return gatewaysCollection.InitializeTtl(clusterId, clusterMembershipOptions.GetMongoTtlTimeSpan(options.UseMongoTtlIndex));
+            return Task.CompletedTask;
         }
 
         private void CreateCollection()

--- a/Orleans.Providers.MongoDB/Membership/MongoMembershipTable.cs
+++ b/Orleans.Providers.MongoDB/Membership/MongoMembershipTable.cs
@@ -17,6 +17,7 @@ namespace Orleans.Providers.MongoDB.Membership
     {
         private readonly IMongoClient mongoClient;
         private readonly ILogger<MongoMembershipTable> logger;
+        private readonly ClusterMembershipOptions clusterMembershipOptions;
         private readonly MongoDBMembershipTableOptions options;
         private readonly string clusterId;
         private IMongoMembershipCollection membershipCollection;
@@ -25,10 +26,12 @@ namespace Orleans.Providers.MongoDB.Membership
             IMongoClientFactory mongoClientFactory,
             ILogger<MongoMembershipTable> logger,
             IOptions<ClusterOptions> clusterOptions,
+            IOptions<ClusterMembershipOptions> clusterMembershipOptions,
             IOptions<MongoDBMembershipTableOptions> options)
         {
             this.mongoClient = mongoClientFactory.Create(options.Value, "Membership");
             this.logger = logger;
+            this.clusterMembershipOptions = clusterMembershipOptions.Value;
             this.options = options.Value;
             this.clusterId = clusterOptions.Value.ClusterId;
         }
@@ -38,7 +41,7 @@ namespace Orleans.Providers.MongoDB.Membership
         {
             membershipCollection = Factory.CreateCollection(mongoClient, options, options.Strategy);
 
-            return Task.CompletedTask;
+            return membershipCollection.InitializeTtl(clusterId, clusterMembershipOptions.GetMongoTtlTimeSpan(options.UseMongoTtlIndex));
         }
 
         /// <inheritdoc />

--- a/Orleans.Providers.MongoDB/Membership/Store/IMongoMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/IMongoMembershipCollection.cs
@@ -20,5 +20,7 @@ namespace Orleans.Providers.MongoDB.Membership.Store
         Task UpdateIAmAlive(string deploymentId, SiloAddress address, DateTime iAmAliveTime);
 
         Task<bool> UpsertRow(string deploymentId, MembershipEntry entry, string etag, TableVersion tableVersion);
+        
+        Task InitializeTtl(string clusterId, TimeSpan? timeToLive);
     }
 }

--- a/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Orleans.Providers.MongoDB.Utils;
 using Orleans.Runtime;
@@ -72,7 +75,62 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Multiple
 
         public Task InitializeTtl(string clusterId, TimeSpan? timeToLive)
         {
-            return Task.CompletedTask;
+            var indexName = $"ttl_{Convert.ToHexString(SHA1.HashData(Encoding.UTF8.GetBytes(clusterId)))}";
+
+            return timeToLive == null
+                ? DropExistingIndexIfNeeded()
+                : UpdateTtlIndexPolicy(timeToLive.Value);
+
+            async Task DropExistingIndexIfNeeded()
+            {
+                try
+                {
+                    // drop the index if it was already created in the past, and the cluster settings revert to explicit
+                    await Collection.Indexes.DropOneAsync(indexName);
+                }
+                catch (MongoCommandException e) when (e.IsIndexMissing())
+                {
+                    // do nothing since the index is already dropped
+                }
+            }
+
+            async Task UpdateTtlIndexPolicy(TimeSpan ttl)
+            {
+                var safeTimeToLive = Math.Round(ttl.TotalSeconds, MidpointRounding.AwayFromZero);
+
+                try
+                {
+                    // in the event that the index already exists, we need to update the TTL policy due to a cluster
+                    // configuration modification
+                    var updateExpireAfterCommand = new BsonDocument()
+                    {
+                        { "collMod", CollectionName() },
+                        {
+                            "index", new BsonDocument
+                            {
+                                { "name", indexName },
+                                { "expireAfterSeconds", safeTimeToLive },
+                            }
+                        },
+                    };
+                    await Database.RunCommandAsync(new BsonDocumentCommand<BsonDocument>(updateExpireAfterCommand));
+                }
+                catch (MongoCommandException e) when (e.IsIndexMissing())
+                {
+                    var keysDefinition = Index.Ascending(x => x.Timestamp);
+                    // ensure that index ttl only applies to documents within the cluster deployment id
+                    var partialFilterExpression = Filter.Eq(x => x.DeploymentId, clusterId);
+                    var indexOptions = new CreateIndexOptions<MongoMembershipDocument>
+                    {
+                        Name = indexName,
+                        ExpireAfter = TimeSpan.FromSeconds(safeTimeToLive),
+                        PartialFilterExpression = partialFilterExpression,
+                    };
+
+                    await Collection.Indexes.CreateOneAsync(
+                        new CreateIndexModel<MongoMembershipDocument>(keysDefinition, indexOptions));
+                }
+            }
         }
 
         private async Task<bool> UpsertRowAsync(IClientSessionHandle session, string deploymentId, MembershipEntry entry, string etag)

--- a/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
@@ -194,8 +194,13 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Multiple
         public Task UpdateIAmAlive(string deploymentId, SiloAddress address, DateTime iAmAliveTime)
         {
             var id = ReturnId(deploymentId, address);
-
-            return Collection.UpdateOneAsync(x => x.Id == id, Update.Set(x => x.IAmAliveTime, LogFormatter.PrintDate(iAmAliveTime)));
+            return Collection.UpdateOneAsync(
+                x => x.Id == id,
+                Update.Combine(
+                    Update.Set(x => x.IAmAliveTime, LogFormatter.PrintDate(iAmAliveTime)),
+                    Update.Set(x => x.Timestamp, iAmAliveTime)
+                )
+            );
         }
 
         public Task CleanupDefunctSiloEntries(string deploymentId, DateTimeOffset beforeDate)

--- a/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Multiple/MultipleMembershipCollection.cs
@@ -70,6 +70,11 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Multiple
             });
         }
 
+        public Task InitializeTtl(string clusterId, TimeSpan? timeToLive)
+        {
+            return Task.CompletedTask;
+        }
+
         private async Task<bool> UpsertRowAsync(IClientSessionHandle session, string deploymentId, MembershipEntry entry, string etag)
         {
             var id = ReturnId(deploymentId, entry.SiloAddress);

--- a/Orleans.Providers.MongoDB/Membership/Store/MultipleDeprecated/MultipleDeprecatedMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/MultipleDeprecated/MultipleDeprecatedMembershipCollection.cs
@@ -74,6 +74,11 @@ namespace Orleans.Providers.MongoDB.Membership.Store.MultipleDeprecated
             }
         }
 
+        public Task InitializeTtl(string clusterId, TimeSpan? timeToLive)
+        {
+            return Task.CompletedTask;
+        }
+
         public async Task<IList<Uri>> GetGateways(string deploymentId)
         {
             var entries =

--- a/Orleans.Providers.MongoDB/Membership/Store/Single/SingleMembershipCollection.cs
+++ b/Orleans.Providers.MongoDB/Membership/Store/Single/SingleMembershipCollection.cs
@@ -136,6 +136,11 @@ namespace Orleans.Providers.MongoDB.Membership.Store.Single
             }
         }
 
+        public Task InitializeTtl(string clusterId, TimeSpan? timeToLive)
+        {
+            return Task.CompletedTask;
+        }
+
         private static string BuildKey(SiloAddress address)
         {
             return address.ToParsableString().Replace('.', '_');

--- a/Orleans.Providers.MongoDB/Utils/ClusterMembershipOptionsExtensions.cs
+++ b/Orleans.Providers.MongoDB/Utils/ClusterMembershipOptionsExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using Orleans.Configuration;
+
+namespace Orleans.Providers.MongoDB.Utils;
+
+internal static class ClusterMembershipOptionsExtensions
+{
+    /// <summary>
+    /// Retrieves the TTL (Time-to-Live) timespan for use in MongoDB TTL indexes based on the provided
+    /// cluster membership options and a flag indicating whether TTL indexing should be used.
+    /// </summary>
+    /// <param name="options">The cluster membership options containing TTL-related configuration.</param>
+    /// <param name="useMongoTtlIndex">Indicates whether a MongoDB TTL index should be utilized.</param>
+    /// <returns>
+    /// A <see cref="TimeSpan"/> representing the TTL duration if <paramref name="useMongoTtlIndex"/> is true;
+    /// otherwise, null.
+    /// </returns>
+    public static TimeSpan? GetMongoTtlTimeSpan(this ClusterMembershipOptions options, bool useMongoTtlIndex)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return useMongoTtlIndex ? options.DefunctSiloExpiration : null;
+    }
+}

--- a/Orleans.Providers.MongoDB/Utils/MongoExtensions.cs
+++ b/Orleans.Providers.MongoDB/Utils/MongoExtensions.cs
@@ -25,6 +25,8 @@ namespace Orleans.Providers.MongoDB.Utils
         }
         
         public static bool IsDuplicateIndex(this MongoCommandException ex) => ex.Code == 85;
+        
+        public static bool IsIndexMissing(this MongoCommandException ex) => ex.Code is 26 or 27;
 
         internal static string GetFieldName<T>(this IMongoCollection<T> collection, Expression<Func<T, object>> expression)
         {

--- a/UnitTest/Fixtures/MongoDatabaseFixture.cs
+++ b/UnitTest/Fixtures/MongoDatabaseFixture.cs
@@ -10,7 +10,12 @@ namespace Orleans.Providers.MongoDB.UnitTest.Fixtures
         private bool disposedValue;
 
         private static readonly Lazy<IMongoRunner> _databaseRunner = new(() => MongoRunner.Run());
-        private static readonly Lazy<IMongoRunner> _replicaSetRunner = new(() => MongoRunner.Run(new MongoRunnerOptions { UseSingleNodeReplicaSet = true }));
+
+        private static readonly Lazy<IMongoRunner> _replicaSetRunner = new(() => MongoRunner.Run(new MongoRunnerOptions
+        {
+            UseSingleNodeReplicaSet = true,
+            AdditionalArguments = "--setParameter ttlMonitorSleepSecs=1"
+        }));
 
         public static string DatabaseConnectionString => _databaseRunner.Value.ConnectionString;
 

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Messaging;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
@@ -34,6 +35,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.ReplicaSetFactory,
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 options);
         }
 
@@ -50,6 +52,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.ReplicaSetFactory,
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 _gatewayOptions,
                 options);
         }

--- a/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_MultipleDeprecated.cs
@@ -6,6 +6,7 @@ using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
 using Orleans.Providers.MongoDB.UnitTest.Fixtures;
 using System.Threading.Tasks;
+using Orleans.Configuration;
 using TestExtensions;
 using UnitTests;
 using UnitTests.MembershipTests;
@@ -35,6 +36,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.DatabaseFactory,
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 options);
         }
 
@@ -51,6 +53,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.DatabaseFactory,
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 _gatewayOptions,
                 options);
         }

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using Orleans.Configuration;
 using Orleans.Messaging;
 using Orleans.Providers.MongoDB.Configuration;
@@ -32,22 +30,8 @@ public class MongoMembershipTableTests_Multiple_Ttl : MembershipTableTestsBase
     {
     }
 
-    private static void SetIndexMonitorFrequency()
-    {
-        var client = MongoDatabaseFixture.ReplicaSetFactory.Create(nameof(MongoMembershipTableTests_Multiple_Ttl));
-        var adminDb = client.GetDatabase("admin");
-
-        adminDb.RunCommand(new BsonDocumentCommand<BsonDocument>(new BsonDocument
-        {
-            { "setParameter", 1 },
-            { "ttlMonitorSleepSecs", MonitorTtlInterval.TotalSeconds }
-        }));
-    }
-
     protected override IMembershipTable CreateMembershipTable(ILogger logger)
     {
-        SetIndexMonitorFrequency();
-        
         var options = Options.Create(new MongoDBMembershipTableOptions
         {
             CollectionPrefix = "TestTtl_",
@@ -66,8 +50,6 @@ public class MongoMembershipTableTests_Multiple_Ttl : MembershipTableTestsBase
 
     protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
     {
-        SetIndexMonitorFrequency();
-        
         var options = Options.Create(new MongoDBGatewayListProviderOptions
         {
             CollectionPrefix = "TestTtl_",

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Orleans.Configuration;
+using Orleans.Messaging;
+using Orleans.Providers.MongoDB.Configuration;
+using Orleans.Providers.MongoDB.Membership;
+using Orleans.Providers.MongoDB.UnitTest.Fixtures;
+using Orleans.Runtime;
+using TestExtensions;
+using UnitTests;
+using UnitTests.MembershipTests;
+using Xunit;
+
+namespace Orleans.Providers.MongoDB.UnitTest.Membership;
+
+[TestCategory("Membership")]
+[TestCategory("Mongo")]
+public class MongoMembershipTableTests_Multiple_Ttl : MembershipTableTestsBase
+{
+    private static readonly TimeSpan MonitorTtlInterval = TimeSpan.FromSeconds(1);
+    private static int _borrowedGeneration;
+    
+    public MongoMembershipTableTests_Multiple_Ttl(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+        : base(fixture, environment, new LoggerFilterOptions())
+    {
+    }
+
+    private static void SetIndexMonitorFrequency()
+    {
+        var client = MongoDatabaseFixture.ReplicaSetFactory.Create(nameof(MongoMembershipTableTests_Multiple_Ttl));
+        var adminDb = client.GetDatabase("admin");
+
+        adminDb.RunCommand(new BsonDocumentCommand<BsonDocument>(new BsonDocument
+        {
+            { "setParameter", 1 },
+            { "ttlMonitorSleepSecs", MonitorTtlInterval.TotalSeconds }
+        }));
+    }
+
+    protected override IMembershipTable CreateMembershipTable(ILogger logger)
+    {
+        SetIndexMonitorFrequency();
+        
+        var options = Options.Create(new MongoDBMembershipTableOptions
+        {
+            CollectionPrefix = "TestTtl_",
+            DatabaseName = "OrleansTest",
+            Strategy = MongoDBMembershipStrategy.Multiple,
+            UseMongoTtlIndex = true
+        });
+
+        return new MongoMembershipTable(
+            MongoDatabaseFixture.ReplicaSetFactory,
+            loggerFactory.CreateLogger<MongoMembershipTable>(),
+            _clusterOptions,
+            Options.Create(new ClusterMembershipOptions()),
+            options);
+    }
+
+    protected override IGatewayListProvider CreateGatewayListProvider(ILogger logger)
+    {
+        SetIndexMonitorFrequency();
+        
+        var options = Options.Create(new MongoDBGatewayListProviderOptions
+        {
+            CollectionPrefix = "TestTtl_",
+            DatabaseName = "OrleansTest",
+            Strategy = MongoDBMembershipStrategy.Multiple,
+            UseMongoTtlIndex = true
+        });
+
+        return new MongoGatewayListProvider(
+            MongoDatabaseFixture.ReplicaSetFactory,
+            loggerFactory.CreateLogger<MongoGatewayListProvider>(),
+            _clusterOptions,
+            Options.Create(new ClusterMembershipOptions()),
+            _gatewayOptions,
+            options);
+    }
+
+    protected override Task<string> GetConnectionString()
+    {
+        return Task.FromResult(MongoDatabaseFixture.ReplicaSetConnectionString);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_CleanupDefunctSiloEntries()
+    {
+        await MembershipTable_CleanupDefunctSiloEntries();
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_GetGateways()
+    {
+        await MembershipTable_GetGateways();
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_ReadAll_EmptyTable()
+    {
+        await MembershipTable_ReadAll_EmptyTable();
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_InsertRow()
+    {
+        await MembershipTable_InsertRow(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_ReadRow_Insert_Read()
+    {
+        await MembershipTable_ReadRow_Insert_Read(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_ReadAll_Insert_ReadAll()
+    {
+        await MembershipTable_ReadAll_Insert_ReadAll(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_UpdateRow()
+    {
+        await MembershipTable_UpdateRow(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_UpdateRowInParallel()
+    {
+        await MembershipTable_UpdateRowInParallel(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_UpdateIAmAlive()
+    {
+        await MembershipTable_UpdateIAmAlive(true);
+    }
+
+    [Fact, TestCategory("Functional")]
+    public async Task Test_VerifyMongoIndexTtl_IsEffective()
+    {
+        // inspired by MembershipTable_CleanupDefunctSiloEntries scenario
+        // note that the CleanupDefunctSiloEntries is not called explicitly. Collection is cleaned up by TTL index
+        
+        var membershipTable = CreateMembershipTable(NullLogger<MongoMembershipTable>.Instance);
+        await membershipTable.InitializeMembershipTable(true).WaitAsync(TimeSpan.FromMinutes(1));
+        
+        MembershipTableData data = await membershipTable.ReadAll();
+        TableVersion newTableVersion = data.Version.Next();
+        
+        var oldEntryDead = CreateMembershipEntryForTest();
+        oldEntryDead.IAmAliveTime = oldEntryDead.IAmAliveTime.AddDays(-10);
+        oldEntryDead.StartTime = oldEntryDead.StartTime.AddDays(-10);
+        oldEntryDead.Status = SiloStatus.Dead;
+        bool ok = await membershipTable.InsertRow(oldEntryDead, newTableVersion);
+        var table = await membershipTable.ReadAll();
+
+        Assert.True(ok, "InsertRow Dead failed");
+
+        newTableVersion = table.Version.Next();
+        var oldEntryJoining = CreateMembershipEntryForTest();
+        oldEntryJoining.IAmAliveTime = oldEntryJoining.IAmAliveTime.AddDays(-10);
+        oldEntryJoining.StartTime = oldEntryJoining.StartTime.AddDays(-10);
+        oldEntryJoining.Status = SiloStatus.Joining;
+        ok = await membershipTable.InsertRow(oldEntryJoining, newTableVersion);
+        table = await membershipTable.ReadAll();
+
+        Assert.True(ok, "InsertRow Joining failed");
+        
+        newTableVersion = table.Version.Next();
+        var staleActiveEntry = CreateMembershipEntryForTest();
+        staleActiveEntry.IAmAliveTime = staleActiveEntry.IAmAliveTime.AddDays(-10);
+        staleActiveEntry.StartTime = staleActiveEntry.StartTime.AddDays(-10);
+        staleActiveEntry.Status = SiloStatus.Active;
+        ok = await membershipTable.InsertRow(staleActiveEntry, newTableVersion);
+        table = await membershipTable.ReadAll();
+
+        Assert.True(ok, "InsertRow Stale Active failed");
+        
+        newTableVersion = table.Version.Next();
+        var  newEntry = CreateMembershipEntryForTest();
+        ok = await membershipTable.InsertRow(newEntry, newTableVersion);
+
+        Assert.True(ok, "InsertRow failed");
+        
+        // we have to wait for the mongo background monitor to trigger. add some buffer
+        await Task.Delay(MonitorTtlInterval + TimeSpan.FromSeconds(5));
+        
+        data = await membershipTable.ReadAll();
+        Assert.Single(data.Members);
+        
+        return;
+
+        static MembershipEntry CreateMembershipEntryForTest()
+        {
+            SiloAddress siloAddress = CreateSiloAddressForTest();
+
+            var membershipEntry = new MembershipEntry
+            {
+                SiloAddress = siloAddress,
+                HostName = Dns.GetHostName(),
+                SiloName = "TestSiloName",
+                Status = SiloStatus.Joining,
+                ProxyPort = siloAddress.Endpoint.Port,
+                StartTime = GetUtcNowWithSecondsResolution(),
+                IAmAliveTime = GetUtcNowWithSecondsResolution()
+            };
+
+            return membershipEntry;
+        }
+        
+        static DateTime GetUtcNowWithSecondsResolution()
+        {
+            var now = DateTime.UtcNow;
+            return new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, now.Second, DateTimeKind.Utc);
+        }
+        
+        static SiloAddress CreateSiloAddressForTest()
+        {
+            var siloAddress = SiloAddressUtils.NewLocalSiloAddress(Interlocked.Increment(ref _borrowedGeneration));
+            siloAddress.Endpoint.Port = 54321;
+            return siloAddress;
+        }
+    }
+}

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
@@ -90,7 +90,7 @@ public class MongoMembershipTableTests_Multiple_Ttl : MembershipTableTestsBase
         return Task.FromResult(MongoDatabaseFixture.ReplicaSetConnectionString);
     }
 
-    [Fact, TestCategory("Functional")]
+    [Fact(Skip = "Assertions made in scenario has false positives due to Mongo TTL dropping"), TestCategory("Functional")]
     public async Task Test_CleanupDefunctSiloEntries()
     {
         await MembershipTable_CleanupDefunctSiloEntries();

--- a/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Multiple_Ttl.cs
@@ -54,8 +54,7 @@ public class MongoMembershipTableTests_Multiple_Ttl : MembershipTableTestsBase
         {
             CollectionPrefix = "TestTtl_",
             DatabaseName = "OrleansTest",
-            Strategy = MongoDBMembershipStrategy.Multiple,
-            UseMongoTtlIndex = true
+            Strategy = MongoDBMembershipStrategy.Multiple
         });
 
         return new MongoGatewayListProvider(

--- a/UnitTest/Membership/MongoMembershipTableTests_Single.cs
+++ b/UnitTest/Membership/MongoMembershipTableTests_Single.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Messaging;
 using Orleans.Providers.MongoDB.Configuration;
 using Orleans.Providers.MongoDB.Membership;
@@ -34,6 +35,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.DatabaseFactory,
                 loggerFactory.CreateLogger<MongoMembershipTable>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 options);
         }
 
@@ -50,6 +52,7 @@ namespace Orleans.Providers.MongoDB.UnitTest.Membership
                 MongoDatabaseFixture.DatabaseFactory,
                 loggerFactory.CreateLogger<MongoGatewayListProvider>(),
                 _clusterOptions,
+                Options.Create(new ClusterMembershipOptions()),
                 _gatewayOptions,
                 options);
         }


### PR DESCRIPTION
This pull request introduces support for automatic cleanup of expired cluster membership and gateway entries in MongoDB by adding optional Time-to-Live (TTL) index management. 

The implementation of the opt-in functionality was inspired by the Cassandra provider: https://github.com/dotnet/orleans/blob/88284521c3b07866403b8817627711dd51e97fd0/src/Cassandra/Orleans.Clustering.Cassandra/Hosting/CassandraClusteringOptions.cs#L30-L36

The changes add configuration options to enable this feature, update the initialization logic to manage TTL indexes, and provide utility methods for TTL handling. Test code is updated to support the new options.